### PR TITLE
Display actions depending on if images are loaded [issue-14]

### DIFF
--- a/cosmoz-image-viewer.html
+++ b/cosmoz-image-viewer.html
@@ -185,6 +185,7 @@ so a user can swipe to the next image.
 		</div>
 
 		<div id="imageContainer" on-scroll="_scrollHandler">
+			<p hidden$="[[_hideNoImageInfo]]">[[ _('No image loaded.', t) ]]</p>
 			<skeleton-carousel id="carousel"
 				selected-item="{{selectedItem}}"
 				dots="[[showDots]]"

--- a/cosmoz-image-viewer.html
+++ b/cosmoz-image-viewer.html
@@ -53,16 +53,16 @@ so a user can swipe to the next image.
 
 			.actions {
 				position: absolute;
-				top: 0;
 				left: 0;
 				right: 0;
-				margin: auto;
-				max-width: 600px;
-				width: 100%;
-				padding: 12px;
+				margin: 12px;
 			}
 
-			.counter {
+			.nav.counter {
+				position: absolute;
+				left: calc(50% - 32px);
+				margin-top: 22px;
+				width: 40px;
 				padding: 4px 10px;
     			border-radius: 30px;
 				text-align: center;
@@ -78,12 +78,6 @@ so a user can swipe to the next image.
 				background-color: rgba(0, 0, 0, 0.44);
 				border-radius: 20px;
 				margin: 3px;
-			}
-
-			.close-btn {
-				position: fixed;
-				right: 12px;
-				top: 12px;
 			}
 
 			#carousel {
@@ -142,52 +136,52 @@ so a user can swipe to the next image.
 
 		</style>
 
+		<div class="nav counter" hidden$="[[!_showPageNumber]]">
+			[[selectedImageNumber]]/[[total]]
+		</div>
+
 		<div class="actions layout horizontal center">
-			<div class="flex"></div>
 			<paper-icon-button
 				class="nav"
-				hidden$="[[!showNav]]"
+				hidden$="[[!_showNav]]"
 				icon="icons:arrow-back"
 				on-tap="previousImage">
 			</paper-icon-button>
 			<paper-icon-button
 				class="nav"
-				hidden$="[[!showNav]]"
+				hidden$="[[!_showNav]]"
 				icon="icons:arrow-forward"
 				on-tap="nextImage">
 			</paper-icon-button>
 			<div class="flex"></div>
-			<div class="nav counter">[[selectedImageNumber]]/[[total]]</div>
-			<div class="flex"></div>
 			<paper-icon-button
 				class="nav"
-				hidden$="[[!showZoom]]"
+				hidden$="[[!_showZoom]]"
 				on-click="zoomToggle"
 				icon="[[_getZoomIcon(isZoomed)]]"
 				title="[[ _('Zoom image', t) ]]">
 			</paper-icon-button>
 			<paper-icon-button
 				class="nav"
-				hidden$="[[!showDetach]]"
+				hidden$="[[!_showDetach]]"
 				on-click="detach"
 				icon="launch"
 				title="[[ _('Detach image to separate window', t) ]]">
 			</paper-icon-button>
 			<paper-icon-button
 				class="nav"
-				hidden$="[[!showFullscreen]]"
+				hidden$="[[!_showFullscreen]]"
 				on-click="openFullscreen"
 				icon="icons:fullscreen"
 				title="[[ _('Fullscreen image', t) ]]">
 			</paper-icon-button>
 			<paper-icon-button
-				class="nav close-btn"
+				class="nav"
 				hidden$="[[!showClose]]"
 				on-click="_close"
 				icon="icons:close"
 				title="[[ _('Close fullscreen', t) ]]">
 			</paper-icon-button>
-			<div class="flex"></div>
 		</div>
 
 		<div id="imageContainer" on-scroll="_scrollHandler">

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -509,10 +509,6 @@
 							padding-right: 24px;
 						}
 
-						.hidden {
-							display: none;
-						}
-
 						.icon-btn {
 							position: inline-block;
 							width: 40px;
@@ -533,6 +529,7 @@
 						.icon-only {
 							width: 24px;
 							height: 24px;
+							cursor: pointer;
 						}
 
 						.icon {

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -191,7 +191,7 @@
 		 * @returns {undefined}
 		 */
 		openFullscreen() {
-			var dialog = document.querySelector('#cosmoz-image-viewer-overlay');
+			let dialog = document.querySelector('#cosmoz-image-viewer-overlay');
 			if (!dialog) {
 				dialog = document.createElement('cosmoz-image-viewer-overlay');
 				dialog.id = 'cosmoz-image-viewer-overlay';
@@ -209,7 +209,7 @@
 		 * @returns {undefined}
 		 */
 		attach() {
-			var sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
+			const sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
 				sharedWindowInstance = sharedWindow.byKey('detachedWindow');
 
 			if (sharedWindowInstance) {
@@ -221,9 +221,8 @@
 		 * @returns {undefined}
 		 */
 		detach() {
-			var sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
-				sharedWindowInstance = sharedWindow.byKey('detachedWindow'),
-				w;
+			const sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
+				sharedWindowInstance = sharedWindow.byKey('detachedWindow');
 
 			if (sharedWindowInstance) {
 				window.open(undefined, 'OCR', 'height=700,width=800');
@@ -231,7 +230,7 @@
 				return;
 			}
 
-			w = window.open(undefined, 'OCR', 'height=700,width=800');
+			let w = window.open(undefined, 'OCR', 'height=700,width=800');
 			w.document.write(this._getDetachedContent());
 			w.document.close();
 			w.document.title = this._('Cosmoz Image Viewer');
@@ -255,7 +254,7 @@
 		 * @returns {undefined}
 		 */
 		zoomToggle() {
-			let el = this.$.carousel.selectedItem.querySelector('img-pan-zoom');
+			const el = this.$.carousel.selectedItem.querySelector('img-pan-zoom');
 			if (!el.viewer) {
 				return;
 			}
@@ -273,7 +272,7 @@
 			if (!selectedItem) {
 				return;
 			}
-			let imgPanZoom = selectedItem.querySelector('img-pan-zoom');
+			const imgPanZoom = selectedItem.querySelector('img-pan-zoom');
 
 			this._initImgPanZoomInstance(imgPanZoom);
 			this.imageLoaded = imgPanZoom.loaded;
@@ -284,7 +283,7 @@
 		},
 
 		_isZoomed(viewer, zoom) {
-			let initialZoomLevel = viewer.viewport.getHomeZoom();
+			const initialZoomLevel = viewer.viewport.getHomeZoom();
 			return zoom > initialZoomLevel * 1.05;
 		},
 
@@ -364,7 +363,7 @@
 		},
 
 		_imageLoadedChanged(e) {
-			var imgPanZoom = e.currentTarget,
+			const imgPanZoom = e.currentTarget,
 				div = imgPanZoom.parentNode;
 
 			if (Array.from(div.classList).indexOf('selected') > -1) {
@@ -375,7 +374,7 @@
 
 		_scrollHandler() {
 			this.debounce('updateScrollPercent', () => {
-				var top = this._scroller.scrollTop,
+				const top = this._scroller.scrollTop,
 					height = this._imageContainerHeight,
 					percent = Math.round(top / height * 100);
 				if (percent !== this.scrollPercent) {
@@ -388,7 +387,7 @@
 			if (!loaded || !this._scroller) {
 				return;
 			}
-			var topPx = height * (percent / 100);
+			const topPx = height * (percent / 100);
 
 			this._scroller.scrollTop = topPx;
 		},
@@ -543,7 +542,7 @@
 					</div>
 					<script>
 						/*eslint no-unused-vars: 0*/
-						var img,
+						let img,
 							images,
 							currentImageIndex = 0;
 
@@ -570,7 +569,7 @@
 								if (!images) {
 									return;
 								}
-								var dl = document.createElement('a');
+								const dl = document.createElement('a');
 
 								images.forEach(imageUrl => {
 									dl.download = imageUrl.replace(/^.*[\\\/]/, '');
@@ -580,18 +579,17 @@
 							},
 
 							printPage = () => {
-								// Add all images to print
-								var printContainer = document.querySelector('#printContainer'),
-									imgs = [];
+								const printContainer = document.querySelector('#printContainer');
+								let imgs;
 
 								printContainer.innerHTML = '';
 
-								images.forEach(imageUrl => {
-									var i = document.createElement('img');
+								imgs = images.map(imageUrl => {
+									const i = document.createElement('img');
 									i.src = imageUrl;
 									i.classList.add('print-image');
-									imgs.push(i);
 									printContainer.appendChild(i);
+									return i;
 								});
 
 								_printIfLoaded(imgs).then(() => {
@@ -612,7 +610,7 @@
 							};
 						window.onload = load;
 						window.setImages = (array, startIndex = 0) => {
-							let imageUrl = array[startIndex];
+							const imageUrl = array[startIndex];
 							images = array;
 							img.src = imageUrl;
 						};

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -543,6 +543,10 @@
 							fill: currentColor;
 						}
 
+						.hidden {
+							display: none;
+						}
+
 						@media print {
 							.hide-on-print {
 								display: none;
@@ -562,12 +566,12 @@
 					<div id="printContainer"></div>
 					<div class="actions hide-on-print">
 						<div class="action-box">
-							<div class="icon-btn" onclick="prev()">
+							<div class="icon-btn nav" onclick="prev()">
 								<svg class="icon" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false">
 									<g><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"></path></g>
 								</svg>
 							</div>
-							<div class="icon-btn" onclick="next()">
+							<div class="icon-btn nav" onclick="next()">
 								<svg class="icon" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false">
 									<g><path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"></path></g>
 								</svg>
@@ -657,9 +661,15 @@
 							};
 						window.onload = load;
 						window.setImages = (array, startIndex = 0) => {
-							const imageUrl = array[startIndex];
+							const imageUrl = array[startIndex],
+								actionsCl = document.querySelector('.actions').classList,
+								navs = document.querySelectorAll('.nav');
 							images = array;
 							img.src = imageUrl;
+
+							// hide/show actions
+							images.length === 0 ? actionsCl.add('hidden') : actionsCl.remove('hidden');
+							navs.forEach(n => images.length > 1 ? n.classList.remove('hidden') : n.classList.add('hidden'));
 						};
 					</script>
 				</body>

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -148,6 +148,11 @@
 
 			// Private
 
+			_hideNoImageInfo: {
+				type: Boolean,
+				computed: '_computeShowActions("true", images.length)'
+			},
+
 			_showNav: {
 				type: Boolean,
 				computed: '_computeShowNav(showNav, images.length)'

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -51,6 +51,9 @@
 			 */
 			images: {
 				type: Array,
+				value() {
+					return [];
+				},
 				observer: '_imageListChanged'
 			},
 			/**
@@ -128,6 +131,13 @@
 				value: false
 			},
 			/**
+			* If true, the current page number (e.g. 2/5) is visible.
+			*/
+			showPageNumber: {
+				type: Boolean,
+				value: false
+			},
+			/**
 			* If true, clicking on next when the last image is selected,
 			* will show the first image again.
 			*/
@@ -138,6 +148,30 @@
 
 			// Private
 
+			_showNav: {
+				type: Boolean,
+				computed: '_computeShowNav(showNav, images.length)'
+			},
+
+			_showZoom: {
+				type: Boolean,
+				computed: '_computeShowActions(showZoom, images.length)'
+			},
+
+			_showDetach: {
+				type: Boolean,
+				computed: '_computeShowActions(showDetach, images.length)'
+			},
+
+			_showFullscreen: {
+				type: Boolean,
+				computed: '_computeShowActions(showFullscreen, images.length)'
+			},
+
+			_showPageNumber: {
+				type: Boolean,
+				computed: '_computeShowActions(showPageNumber, images.length)'
+			},
 			/**
 			 * The url resolved images array.
 			 */
@@ -267,6 +301,14 @@
 		},
 
 		/** ELEMENT BEHAVIOR */
+
+		_computeShowNav(showNav, imagesLen) {
+			return showNav ? imagesLen > 1 : false;
+		},
+
+		_computeShowActions(show, imagesLen) {
+			return show ? imagesLen > 0 : false;
+		},
 
 		_selectedItemChanged(selectedItem) {
 			if (!selectedItem) {

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -543,7 +543,7 @@
 							fill: currentColor;
 						}
 
-						.hidden {
+						[hidden] {
 							display: none;
 						}
 
@@ -662,15 +662,14 @@
 						window.onload = load;
 						window.setImages = (array, startIndex = 0) => {
 							const imageUrl = array[startIndex],
-								actionsCl = document.querySelector('.actions').classList,
+								actions = document.querySelector('.actions'),
 								navs = document.querySelectorAll('.nav');
-							const imageUrl = array[startIndex];
 							images = array;
 							img.src = imageUrl;
 
 							// hide/show actions
-							images.length === 0 ? actionsCl.add('hidden') : actionsCl.remove('hidden');
-							navs.forEach(n => images.length > 1 ? n.classList.remove('hidden') : n.classList.add('hidden'));
+							actions.hidden = images.length === 0 ? true : false;
+							navs.forEach(n => n.hidden = images.length > 1 ? false : true);
 						};
 					</script>
 				</body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -29,7 +29,7 @@
 						<template is="dom-bind" class="scope"><!-- for Polymer 1 -->
 							<cosmoz-image-viewer
 								images="[[images]]"
-								show-nav loop show-fullscreen show-detach>
+								show-nav loop show-fullscreen show-detach show-page-number>
 							</cosmoz-image-viewer>
 						</template>
 					</dom-bind>

--- a/demo/index.html
+++ b/demo/index.html
@@ -60,8 +60,8 @@
 		</div>
 
 		<script type="text/javascript">
-		(function () {
-			window.addEventListener('WebComponentsReady', function () {
+		(() => {
+			window.addEventListener('WebComponentsReady', () => {
 				var images = [
 					'demo/images/stockholm.jpg',
 					'demo/images/a_size.png',


### PR DESCRIPTION
see issue https://github.com/Neovici/cosmoz-image-viewer/issues/14

- Added `show-page-number` property
- Display actions only if an image is loaded
- Display navigation only if more than 1 image is loaded

Please merge https://github.com/Neovici/cosmoz-frontend/pull/57 afterwards.
