### PR TITLE
Shared detached window (cosmoz-data-nav) [issue-2]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "iron-overlay-behavior": "^2.2.0"
   },
   "devDependencies": {
+    "cosmoz-data-nav": "neovici/cosmoz-data-nav#master",
     "iron-component-page": "PolymerElements/iron-component-page#1 - 3",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#1 - 2",
     "iron-test-helpers": "polymerelements/iron-test-helpers#1 - 2",

--- a/cosmoz-image-viewer.html
+++ b/cosmoz-image-viewer.html
@@ -214,9 +214,6 @@ so a user can swipe to the next image.
 				</template>
 			</skeleton-carousel>
 		</div>
-
-		<iron-meta id="meta" type="cosmoz-image-viewer" key="detachedWindow"></iron-meta>
-
 	</template>
 	<script type="text/javascript" src="cosmoz-image-viewer.js"></script>
 </dom-module>

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -191,7 +191,7 @@
 		 * @returns {undefined}
 		 */
 		openFullscreen() {
-			var dialog = document.querySelector('#cosmoz-image-viewer-overlay');
+			let dialog = document.querySelector('#cosmoz-image-viewer-overlay');
 			if (!dialog) {
 				dialog = document.createElement('cosmoz-image-viewer-overlay');
 				dialog.id = 'cosmoz-image-viewer-overlay';
@@ -209,7 +209,7 @@
 		 * @returns {undefined}
 		 */
 		attach() {
-			var sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
+			const sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
 				sharedWindowInstance = sharedWindow.byKey('detachedWindow');
 
 			if (sharedWindowInstance) {
@@ -221,9 +221,8 @@
 		 * @returns {undefined}
 		 */
 		detach() {
-			var sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
-				sharedWindowInstance = sharedWindow.byKey('detachedWindow'),
-				w;
+			const sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
+				sharedWindowInstance = sharedWindow.byKey('detachedWindow');
 
 			if (sharedWindowInstance) {
 				window.open(undefined, 'OCR', 'height=700,width=800');
@@ -231,7 +230,7 @@
 				return;
 			}
 
-			w = window.open(undefined, 'OCR', 'height=700,width=800');
+			let w = window.open(undefined, 'OCR', 'height=700,width=800');
 			w.document.write(this._getDetachedContent());
 			w.document.close();
 			w.document.title = this._('Cosmoz Image Viewer');
@@ -255,7 +254,7 @@
 		 * @returns {undefined}
 		 */
 		zoomToggle() {
-			let el = this.$.carousel.selectedItem.querySelector('img-pan-zoom');
+			const el = this.$.carousel.selectedItem.querySelector('img-pan-zoom');
 			if (!el.viewer) {
 				return;
 			}
@@ -273,7 +272,7 @@
 			if (!selectedItem) {
 				return;
 			}
-			let imgPanZoom = selectedItem.querySelector('img-pan-zoom');
+			const imgPanZoom = selectedItem.querySelector('img-pan-zoom');
 
 			this._initImgPanZoomInstance(imgPanZoom);
 			this.imageLoaded = imgPanZoom.loaded;
@@ -284,7 +283,7 @@
 		},
 
 		_isZoomed(viewer, zoom) {
-			let initialZoomLevel = viewer.viewport.getHomeZoom();
+			const initialZoomLevel = viewer.viewport.getHomeZoom();
 			return zoom > initialZoomLevel * 1.05;
 		},
 
@@ -364,7 +363,7 @@
 		},
 
 		_imageLoadedChanged(e) {
-			var imgPanZoom = e.currentTarget,
+			const imgPanZoom = e.currentTarget,
 				div = imgPanZoom.parentNode;
 
 			if (Array.from(div.classList).indexOf('selected') > -1) {
@@ -375,7 +374,7 @@
 
 		_scrollHandler() {
 			this.debounce('updateScrollPercent', () => {
-				var top = this._scroller.scrollTop,
+				const top = this._scroller.scrollTop,
 					height = this._imageContainerHeight,
 					percent = Math.round(top / height * 100);
 				if (percent !== this.scrollPercent) {
@@ -388,7 +387,7 @@
 			if (!loaded || !this._scroller) {
 				return;
 			}
-			var topPx = height * (percent / 100);
+			const topPx = height * (percent / 100);
 
 			this._scroller.scrollTop = topPx;
 		},
@@ -543,7 +542,7 @@
 					</div>
 					<script>
 						/*eslint no-unused-vars: 0*/
-						var img,
+						let img,
 							images,
 							currentImageIndex = 0;
 
@@ -570,7 +569,7 @@
 								if (!images) {
 									return;
 								}
-								var dl = document.createElement('a');
+								const dl = document.createElement('a');
 
 								images.forEach(imageUrl => {
 									dl.download = imageUrl.replace(/^.*[\\\/]/, '');
@@ -580,18 +579,17 @@
 							},
 
 							printPage = () => {
-								// Add all images to print
-								var printContainer = document.querySelector('#printContainer'),
-									imgs = [];
+								const printContainer = document.querySelector('#printContainer');
+								let imgs;
 
 								printContainer.innerHTML = '';
 
-								images.forEach(imageUrl => {
-									var i = document.createElement('img');
+								imgs = images.map(imageUrl => {
+									const i = document.createElement('img');
 									i.src = imageUrl;
 									i.classList.add('print-image');
-									imgs.push(i);
 									printContainer.appendChild(i);
+									return i;
 								});
 
 								_printIfLoaded(imgs).then(() => {
@@ -612,7 +610,7 @@
 							};
 						window.onload = load;
 						window.setImages = (array, startIndex = 0) => {
-							let imageUrl = array[startIndex];
+							const imageUrl = array[startIndex];
 							images = array;
 							img.src = imageUrl;
 						};

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -209,8 +209,8 @@
 		 * @returns {undefined}
 		 */
 		attach() {
-			const sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
-				sharedWindowInstance = sharedWindow.byKey('detachedWindow');
+			const ironMeta = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
+				sharedWindowInstance = ironMeta.byKey('detachedWindow');
 
 			if (sharedWindowInstance) {
 				sharedWindowInstance.close();
@@ -221,12 +221,17 @@
 		 * @returns {undefined}
 		 */
 		detach() {
-			const sharedWindow = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
-				sharedWindowInstance = sharedWindow.byKey('detachedWindow');
+			const ironMeta = new Polymer.IronMeta({type: 'cosmoz-image-viewer', key: 'detachedWindow'}),
+				sharedWindowInstance = ironMeta.byKey('detachedWindow');
 
 			if (sharedWindowInstance) {
+				sharedWindowInstance.addEventListener('instanceupdate', () => {
+					this._setIsDetached(false);
+				});
 				window.open(undefined, 'OCR', 'height=700,width=800');
 				sharedWindowInstance.setImages(this._resolvedImages, this.currentImageIndex);
+				sharedWindowInstance.dispatchEvent(new Event('instanceupdate'));
+				this._setIsDetached(true);
 				return;
 			}
 
@@ -242,11 +247,15 @@
 			w.addEventListener('beforeunload', () => {
 				this._setIsDetached(false);
 				this.notifyResize();
-				sharedWindow.value = undefined;
+				ironMeta.value = undefined;
+			});
+
+			w.addEventListener('instanceupdate', () => {
+				this._setIsDetached(false);
 			});
 
 			this._setIsDetached(true);
-			sharedWindow.value = w;
+			ironMeta.value = w;
 			this.notifyResize();
 		},
 		/**

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -225,13 +225,16 @@
 				sharedWindowInstance = ironMeta.byKey('detachedWindow');
 
 			if (sharedWindowInstance) {
-				sharedWindowInstance.addEventListener('instanceupdate', () => {
+				sharedWindowInstance.addEventListener('instanceupdate', (e) => {
+					if (e.detail === this) {
+						this._setIsDetached(true);
+						return;
+					}
 					this._setIsDetached(false);
 				});
 				sharedWindowInstance.open(undefined, 'OCR', 'height=700,width=800');
 				sharedWindowInstance.setImages(this._resolvedImages, this.currentImageIndex);
-				sharedWindowInstance.dispatchEvent(new Event('instanceupdate'));
-				this._setIsDetached(true);
+				sharedWindowInstance.dispatchEvent(new CustomEvent('instanceupdate', {detail: this}));
 				return;
 			}
 			// Call load() manually in case window already exists and onload event already fired.
@@ -255,11 +258,15 @@
 				ironMeta.value = undefined;
 			});
 
-			w.addEventListener('instanceupdate', () => {
+			w.addEventListener('instanceupdate', (e) => {
+				if (e.detail === this) {
+					this._setIsDetached(true);
+					return;
+				}
 				this._setIsDetached(false);
 			});
 
-			this._setIsDetached(true);
+			w.dispatchEvent(new CustomEvent('instanceupdate', {detail: this}));
 			ironMeta.value = w;
 			this.notifyResize();
 		},

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -524,7 +524,7 @@
 						}
 					</style>
 				</head>
-				<body>
+				<body onload="load()">
 					<img id="image" class="hide-on-print">
 					<div id="printContainer"></div>
 					<div class="actions hide-on-print">
@@ -556,17 +556,16 @@
 					</div>
 					<script>
 						/*eslint no-unused-vars: 0*/
-						let img,
-							images,
+						let images,
 							currentImageIndex = 0;
 
-						const init = () => {
-								img = document.querySelector('#image');
-							},
+						const
+							img = document.querySelector('#image'),
+
 							load = () =>  {
-								init();
 								dispatchEvent(new Event('ready', { bubbles: true }));
-							}
+							},
+
 							next = () => {
 								if (currentImageIndex === images.length - 1) {
 									return;
@@ -574,6 +573,7 @@
 								currentImageIndex++;
 								img.src = images[currentImageIndex];
 							},
+
 							prev = () => {
 								if (currentImageIndex === 0) {
 									return;
@@ -613,6 +613,7 @@
 									printContainer.innerHTML = '';
 								});
 							},
+
 							_printIfLoaded = (imgs) => {
 								return new Promise((resolve, reject) => {
 									setTimeout(() => {
@@ -626,13 +627,11 @@
 								});
 							};
 
-						onload = load;
-
-						setImages = (array, startIndex = 0) => {
-							const imageUrl = array[startIndex];
-							images = array;
-							img.src = imageUrl;
-						};
+							setImages = (array, startIndex = 0) => {
+								const imageUrl = array[startIndex];
+								images = array;
+								img.src = imageUrl;
+							};
 					</script>
 				</body>
 			</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,12 +10,17 @@
 
 		<link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html" />
 		<link rel="import" href="../../iron-demo-helpers/demo-snippet.html" />
-
+		<link rel="import" href="../../cosmoz-data-nav/cosmoz-data-nav.html">
 
 		<link rel="import" href="../cosmoz-image-viewer.html" />
 
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles iron-flex">
+				cosmoz-data-nav {
+					display: block;
+					height: 600px;
+					position: relative;
+				}
 			</style>
 		</custom-style>
 
@@ -35,6 +40,7 @@
 					</dom-bind>
 				</template>
 			</demo-snippet>
+
 			<h3>Zooming <code>cosmoz-image-viewer</code>.</h3>
 			<demo-snippet>
 				<template>
@@ -57,11 +63,36 @@
 					</dom-bind>
 				</template>
 			</demo-snippet>
+
+			<h3><code>cosmoz-image-viewer</code> via <code>cosmoz-data-nav</code></h3>
+			<demo-snippet>
+				<template>
+					<dom-bind class="scope data-nav"><!-- for Polymer 2 -->
+						<template is="dom-bind" class="scope data-nav"><!-- for Polymer 1 -->
+							<cosmoz-data-nav index-as="index" item-as="item" items="[[items]]" on-need-data="onNeedData">
+									<template>
+										<div class="fit layout vertical" style$="background-color: {{ computeColor(index) }}">
+											<div>
+												<paper-icon-button slot="actions" disabled$="[[ prevDisabled ]]" icon="chevron-left" cosmoz-data-nav-select="-1"></paper-icon-button>
+												<span>[[index]]</span>
+												<paper-icon-button slot="actions" disabled$="[[ nextDisabled ]]" icon="chevron-right" cosmoz-data-nav-select="+1"></paper-icon-button>
+											</div>
+											<cosmoz-image-viewer id$="[[index]]"
+												images="[[images]]"
+												show-nav loop show-detach>
+											</cosmoz-image-viewer>
+										</div>
+									</template>
+								</cosmoz-data-nav>
+						</template>
+					</dom-bind>
+				</template>
+			</demo-snippet>
 		</div>
 
 		<script type="text/javascript">
-		(function () {
-			window.addEventListener('WebComponentsReady', function () {
+		(() => {
+			window.addEventListener('WebComponentsReady', () => {
 				var images = [
 					'demo/images/stockholm.jpg',
 					'demo/images/a_size.png',
@@ -69,6 +100,20 @@
 					return i % 2 === 0 ? 'demo/images/stockholm.jpg' : 'demo/images/strasbourg.jpg';
 				}));
 				document.querySelectorAll('.scope').forEach(s => s.images = images);
+
+				// cosmoz-data-nav
+				document.querySelectorAll('.data-nav').forEach(d => {
+					d.onNeedData = function (event, detail) {
+						setTimeout(() => {
+							event.target.setItemById(detail.id, { id: detail.id });
+						}, 2000);
+						return { id: detail.id };
+					};
+					d.computeColor = function () {
+						return '#' + Math.random().toString(16).slice(-3);
+					};
+					d.items = Array.from(new Array(5), (_, i) => i.toString());
+				});
 			});
 		})();
 		</script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
 				<template>
 					<dom-bind class="scope"><!-- for Polymer 2 -->
 						<template is="dom-bind" class="scope"><!-- for Polymer 1 -->
-							<cosmoz-image-viewer
+							<cosmoz-image-viewer id="first"
 								images="[[images]]"
 								show-nav loop show-fullscreen show-detach>
 							</cosmoz-image-viewer>
@@ -49,7 +49,7 @@
 									}
 								</style>
 							</custom-style>
-							<cosmoz-image-viewer class="viewer"
+							<cosmoz-image-viewer class="viewer" id="second"
 								images="[[images]]"
 								show-nav loop show-fullscreen show-detach show-zoom>
 							</cosmoz-image-viewer>

--- a/demo/index.html
+++ b/demo/index.html
@@ -65,41 +65,9 @@
 				var images = [
 					'demo/images/stockholm.jpg',
 					'demo/images/a_size.png',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg',
-					'demo/images/strasbourg.jpg',
-					'demo/images/stockholm.jpg'
-				];
+				].concat(...Array.from(new Array(30), (_, i) => {
+					return i % 2 === 0 ? 'demo/images/stockholm.jpg' : 'demo/images/strasbourg.jpg';
+				}));
 				document.querySelectorAll('.scope').forEach(s => s.images = images);
 			});
 		})();


### PR DESCRIPTION
See issue https://github.com/Neovici/cosmoz-image-viewer/issues/14
---
I stumbled upon an issue while using `cosmoz-data-nav`:
1. Go to `cosmoz-image-viewer's` demo
2. Detach image of `cosmoz-image-viewer` in data-nav's slide 0
=> `cosmoz-image-viewer` of data-nav's slide 0 gets detached.
3. Go to  data-nav's slide '3'
=> you'll see thats it's also hidden (detached)

This might be happening because of reusing elements in `cosmoz-data-nav`?
Not sure if I should solve this issue here or if its's a `cosmoz-data-nav` issue..