### PR TITLE
Scale image width on resize [issue-19]

### DIFF
--- a/cosmoz-image-viewer.html
+++ b/cosmoz-image-viewer.html
@@ -117,11 +117,11 @@ so a user can swipe to the next image.
 			}
 
 			.image {
-				@apply --layout-flex-auto;
-				display: flex;
-				justify-content: center;
 				background-color: gray;
 				pointer-events: none;
+				--iron-image-width: 100%;
+				--iron-image-height: auto;
+				@apply --cosmoz-image-viewer-image;
 			}
 
 			.image-zoom {
@@ -136,11 +136,11 @@ so a user can swipe to the next image.
 
 		</style>
 
-		<div class="nav counter" hidden$="[[!_showPageNumber]]">
+		<div class="nav counter hide-on-small-height" hidden$="[[!_showPageNumber]]">
 			[[selectedImageNumber]]/[[total]]
 		</div>
 
-		<div class="actions layout horizontal center">
+		<div class="actions layout horizontal center hide-on-small-height">
 			<paper-icon-button
 				class="nav"
 				hidden$="[[!_showNav]]"

--- a/cosmoz-image-viewer.html
+++ b/cosmoz-image-viewer.html
@@ -136,11 +136,11 @@ so a user can swipe to the next image.
 
 		</style>
 
-		<div class="nav counter hide-on-small-height" hidden$="[[!_showPageNumber]]">
+		<div class="nav counter" hidden$="[[!_showPageNumber]]">
 			[[selectedImageNumber]]/[[total]]
 		</div>
 
-		<div class="actions layout horizontal center hide-on-small-height">
+		<div class="actions layout horizontal center">
 			<paper-icon-button
 				class="nav"
 				hidden$="[[!_showNav]]"

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -392,6 +392,14 @@
 
 		_onResize() {
 			this.set('_imageContainerHeight', this._scroller.scrollHeight);
+			this.debounce('hideAbsoluteContentOnSmallHeight', () => {
+				const absElements = Polymer.dom(this.root).querySelectorAll('.hide-on-small-height');
+				if (this.offsetHeight < 100) {
+					absElements.forEach(el => el.setAttribute('hidden', true));
+					return;
+				}
+				absElements.forEach(el => el.removeAttribute('hidden'));
+			}, 50);
 		},
 
 		_detachedChanged(value) {

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -148,6 +148,11 @@
 
 			// Private
 
+			_elementHeight: {
+				type: Number,
+				value: 0
+			},
+
 			_hideNoImageInfo: {
 				type: Boolean,
 				computed: '_computeShowActions("true", images.length)'
@@ -155,27 +160,27 @@
 
 			_showNav: {
 				type: Boolean,
-				computed: '_computeShowNav(showNav, images.length)'
+				computed: '_computeShowActions(showNav, images.length, _elementHeight, 2)'
 			},
 
 			_showZoom: {
 				type: Boolean,
-				computed: '_computeShowActions(showZoom, images.length)'
+				computed: '_computeShowActions(showZoom, images.length, _elementHeight)'
 			},
 
 			_showDetach: {
 				type: Boolean,
-				computed: '_computeShowActions(showDetach, images.length)'
+				computed: '_computeShowActions(showDetach, images.length, _elementHeight)'
 			},
 
 			_showFullscreen: {
 				type: Boolean,
-				computed: '_computeShowActions(showFullscreen, images.length)'
+				computed: '_computeShowActions(showFullscreen, images.length, _elementHeight)'
 			},
 
 			_showPageNumber: {
 				type: Boolean,
-				computed: '_computeShowActions(showPageNumber, images.length)'
+				computed: '_computeShowActions(showPageNumber, images.length, _elementHeight)'
 			},
 			/**
 			 * The url resolved images array.
@@ -307,12 +312,9 @@
 
 		/** ELEMENT BEHAVIOR */
 
-		_computeShowNav(showNav, imagesLen) {
-			return showNav ? imagesLen > 1 : false;
-		},
-
-		_computeShowActions(show, imagesLen) {
-			return show ? imagesLen > 0 : false;
+		_computeShowActions(show, imagesLen, height, imgsMinLen = 1) {
+			const heightOk = height ? height > 100 : true;
+			return show ? imagesLen >= imgsMinLen && heightOk : false;
 		},
 
 		_selectedItemChanged(selectedItem) {
@@ -392,13 +394,8 @@
 
 		_onResize() {
 			this.set('_imageContainerHeight', this._scroller.scrollHeight);
-			this.debounce('hideAbsoluteContentOnSmallHeight', () => {
-				const absElements = Polymer.dom(this.root).querySelectorAll('.hide-on-small-height');
-				if (this.offsetHeight < 100) {
-					absElements.forEach(el => el.setAttribute('hidden', true));
-					return;
-				}
-				absElements.forEach(el => el.removeAttribute('hidden'));
+			this.debounce('elementHeight', () => {
+				this._elementHeight = this.offsetHeight;
 			}, 50);
 		},
 


### PR DESCRIPTION
See https://github.com/Neovici/cosmoz-image-viewer/issues/19

- Scale image width
- Hide `position: absolute` elements if height gets small (solves issue in an iron-collapse (cosmoz-tabs) where only navigation is shown even though element height is 4px)