### PR TITLE
Fix memory leak in img-pan-zoom

### DIFF
--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -223,7 +223,7 @@
 			this.cancelDebouncer('setResolvedImages');
 
 			Array.from(Polymer.dom(this.root).querySelectorAll('img-pan-zoom'))
-				.forEach((img)=> img.destroy());
+				.forEach((img)=> img && img.viewer && img.destroy());
 		},
 
 		/** PUBLIC */

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -221,6 +221,9 @@
 			this.cancelDebouncer('updateScrollPercent');
 			this.cancelDebouncer('elementHeight');
 			this.cancelDebouncer('setResolvedImages');
+
+			Array.from(Polymer.dom(this.root).querySelectorAll('img-pan-zoom'))
+				.forEach((img)=> img.destroy());
 		},
 
 		/** PUBLIC */


### PR DESCRIPTION
Fix memory leak in img-pan-zoom

https://github.com/ryanburns23/img-pan-zoom/blob/master/img-pan-zoom.html#L223 ->
OpenSeaDragon viewer should be destroyed on detach.