### PR TITLE
External window updates

### DIFF
--- a/cosmoz-image-viewer.html
+++ b/cosmoz-image-viewer.html
@@ -40,7 +40,9 @@ so a user can swipe to the next image.
 				position: relative;
 				@apply --layout-vertical;
 			}
+
 			/* For Polymer 2 */
+
 			[hidden] {
 				display: none !important;
 			}
@@ -63,7 +65,7 @@ so a user can swipe to the next image.
 				margin-top: 22px;
 				width: 40px;
 				padding: 4px 10px;
-    			border-radius: 30px;
+				border-radius: 30px;
 				text-align: center;
 				font-weight: 100;
 				font-size: 1em;
@@ -72,7 +74,7 @@ so a user can swipe to the next image.
 			.nav {
 				z-index: +1;
 				opacity: 0.5;
-				color:rgba(255, 255, 255, 0.87);
+				color: rgba(255, 255, 255, 0.87);
 				opacity: 1;
 				background-color: rgba(0, 0, 0, 0.44);
 				border-radius: 20px;
@@ -132,7 +134,6 @@ so a user can swipe to the next image.
 				height: 100vh;
 				@apply --cosmoz-image-viewer-image-zoom;
 			}
-
 		</style>
 
 		<div class="nav counter" hidden$="[[!_showPageNumber]]">
@@ -214,6 +215,7 @@ so a user can swipe to the next image.
 				html,
 				body {
 					margin: 0;
+					font-family: sans-serif;
 				}
 
 				body {
@@ -225,7 +227,7 @@ so a user can swipe to the next image.
 					width: 100%;
 				}
 
-				.actions {
+				#actions {
 					position: fixed;
 					left: 0;
 					top: 0;
@@ -241,9 +243,10 @@ so a user can swipe to the next image.
 					-o-transition: opacity .25s ease-in-out;
 					transition: opacity .25s ease-in-out;
 					transition-delay: 0s;
+					color: rgba(255, 255, 255, 0.87);
 				}
 
-				.actions:hover {
+				#actions:hover {
 					opacity: 1;
 					transition-delay: 0s;
 				}
@@ -258,9 +261,11 @@ so a user can swipe to the next image.
 					font-size: 2em;
 				}
 
-				.space {
+				#space {
 					width: 100%;
 					text-align: center;
+					font-size: 1.1em;
+					letter-spacing: 0.2em;
 				}
 
 				.action-box {
@@ -289,8 +294,10 @@ so a user can swipe to the next image.
 					margin: 6px;
 				}
 
-				.icon-only, .icon-btn {
-					color: rgba(255, 255, 255, 0.87);
+				.icon-btn[disabled] {
+					cursor: default;
+					background-color: rgba(0, 0, 0, 0.2);
+					color: rgba(255, 255, 255, 0.4);
 				}
 
 				.icon-only {
@@ -323,122 +330,350 @@ so a user can swipe to the next image.
 						width: 100%;
 					}
 				}
+
+				#loading {
+					position: absolute;
+					left: 0;
+					top: 0;
+					right: 0;
+					bottom: 0;
+					background-color:#eee;
+					opacity: 0.7;
+				}
+
+				#loaderHolder {
+					position: absolute;
+					left: 50%;
+					top: 50%;
+					margin-left: -40px;
+					margin-top: -40px;
+				}
+
+				.sk-circle {
+					width: 80px;
+					height: 80px;
+					position: relative;
+				}
+
+				.sk-circle .sk-child {
+					width: 100%;
+					height: 100%;
+					position: absolute;
+					left: 0;
+					top: 0;
+				}
+
+				.sk-circle .sk-child:before {
+					content: '';
+					display: block;
+					margin: 0 auto;
+					width: 15%;
+					height: 15%;
+					background-color: rgb(95, 90, 146);
+					border-radius: 100%;
+					-webkit-animation: sk-circleBounceDelay 1.2s infinite ease-in-out both;
+					animation: sk-circleBounceDelay 1.2s infinite ease-in-out both;
+				}
+
+				.sk-circle .sk-circle2 {
+					-webkit-transform: rotate(30deg);
+					-ms-transform: rotate(30deg);
+					transform: rotate(30deg);
+				}
+
+				.sk-circle .sk-circle3 {
+					-webkit-transform: rotate(60deg);
+					-ms-transform: rotate(60deg);
+					transform: rotate(60deg);
+				}
+
+				.sk-circle .sk-circle4 {
+					-webkit-transform: rotate(90deg);
+					-ms-transform: rotate(90deg);
+					transform: rotate(90deg);
+				}
+
+				.sk-circle .sk-circle5 {
+					-webkit-transform: rotate(120deg);
+					-ms-transform: rotate(120deg);
+					transform: rotate(120deg);
+				}
+
+				.sk-circle .sk-circle6 {
+					-webkit-transform: rotate(150deg);
+					-ms-transform: rotate(150deg);
+					transform: rotate(150deg);
+				}
+
+				.sk-circle .sk-circle7 {
+					-webkit-transform: rotate(180deg);
+					-ms-transform: rotate(180deg);
+					transform: rotate(180deg);
+				}
+
+				.sk-circle .sk-circle8 {
+					-webkit-transform: rotate(210deg);
+					-ms-transform: rotate(210deg);
+					transform: rotate(210deg);
+				}
+
+				.sk-circle .sk-circle9 {
+					-webkit-transform: rotate(240deg);
+					-ms-transform: rotate(240deg);
+					transform: rotate(240deg);
+				}
+
+				.sk-circle .sk-circle10 {
+					-webkit-transform: rotate(270deg);
+					-ms-transform: rotate(270deg);
+					transform: rotate(270deg);
+				}
+
+				.sk-circle .sk-circle11 {
+					-webkit-transform: rotate(300deg);
+					-ms-transform: rotate(300deg);
+					transform: rotate(300deg);
+				}
+
+				.sk-circle .sk-circle12 {
+					-webkit-transform: rotate(330deg);
+					-ms-transform: rotate(330deg);
+					transform: rotate(330deg);
+				}
+
+				.sk-circle .sk-circle2:before {
+					-webkit-animation-delay: -1.1s;
+					animation-delay: -1.1s;
+				}
+
+				.sk-circle .sk-circle3:before {
+					-webkit-animation-delay: -1s;
+					animation-delay: -1s;
+				}
+
+				.sk-circle .sk-circle4:before {
+					-webkit-animation-delay: -0.9s;
+					animation-delay: -0.9s;
+				}
+
+				.sk-circle .sk-circle5:before {
+					-webkit-animation-delay: -0.8s;
+					animation-delay: -0.8s;
+				}
+
+				.sk-circle .sk-circle6:before {
+					-webkit-animation-delay: -0.7s;
+					animation-delay: -0.7s;
+				}
+
+				.sk-circle .sk-circle7:before {
+					-webkit-animation-delay: -0.6s;
+					animation-delay: -0.6s;
+				}
+
+				.sk-circle .sk-circle8:before {
+					-webkit-animation-delay: -0.5s;
+					animation-delay: -0.5s;
+				}
+
+				.sk-circle .sk-circle9:before {
+					-webkit-animation-delay: -0.4s;
+					animation-delay: -0.4s;
+				}
+
+				.sk-circle .sk-circle10:before {
+					-webkit-animation-delay: -0.3s;
+					animation-delay: -0.3s;
+				}
+
+				.sk-circle .sk-circle11:before {
+					-webkit-animation-delay: -0.2s;
+					animation-delay: -0.2s;
+				}
+
+				.sk-circle .sk-circle12:before {
+					-webkit-animation-delay: -0.1s;
+					animation-delay: -0.1s;
+				}
+
+				@-webkit-keyframes sk-circleBounceDelay {
+					0%,
+					80%,
+					100% {
+						-webkit-transform: scale(0);
+						transform: scale(0);
+					}
+					40% {
+						-webkit-transform: scale(1);
+						transform: scale(1);
+					}
+				}
+
+				@keyframes sk-circleBounceDelay {
+					0%,
+					80%,
+					100% {
+						-webkit-transform: scale(0);
+						transform: scale(0);
+					}
+					40% {
+						-webkit-transform: scale(1);
+						transform: scale(1);
+					}
+				}
 			</style>
 
 			<img id="image" class="hide-on-print">
 			<div id="printContainer"></div>
-			<div class="actions hide-on-print">
+			<div id="actions" class="hide-on-print">
 				<div class="action-box">
-					<div class="icon-btn nav" onclick="prev()">
+					<div id="prevImg" class="icon-btn nav" onclick="ciw.actions.prev()">
 						<svg class="icon" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false">
 							<g><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"></path></g>
 						</svg>
 					</div>
-					<div class="icon-btn nav" onclick="next()">
+					<div id="nextImg" class="icon-btn nav" onclick="ciw.actions.next()">
 						<svg class="icon" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false">
 							<g><path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"></path></g>
 						</svg>
 					</div>
 				</div>
-				<span class="space"></span>
+				<span id="space"></span>
 				<div class="action-box">
-					<div class="icon-only" onclick="downloadImages()">
+					<div class="icon-only" onclick="ciw.actions.downloadImages()">
 						<svg class="icon" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false">
 							<g><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"></path></g>
 						</svg>
 					</div>
-					<div class="icon-only" onclick="printPage()">
+					<div class="icon-only" onclick="ciw.actions.printPage()">
 						<svg class="icon" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false">
 							<g><path d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"></path></g>
 						</svg>
 					</div>
 				</div>
 			</div>
+			<div id="loading">
+				<div id="loaderHolder">
+					<div class="sk-circle">
+						<div class="sk-circle1 sk-child"></div>
+						<div class="sk-circle2 sk-child"></div>
+						<div class="sk-circle3 sk-child"></div>
+						<div class="sk-circle4 sk-child"></div>
+						<div class="sk-circle5 sk-child"></div>
+						<div class="sk-circle6 sk-child"></div>
+						<div class="sk-circle7 sk-child"></div>
+						<div class="sk-circle8 sk-child"></div>
+						<div class="sk-circle9 sk-child"></div>
+						<div class="sk-circle10 sk-child"></div>
+						<div class="sk-circle11 sk-child"></div>
+						<div class="sk-circle12 sk-child"></div>
+					</div>
+				</div>
+			</div>
 			<script>
-				/*eslint no-unused-vars: 0*/
-				let img,
-					images,
-					currentImageIndex = 0;
+				/*eslint-env browser*/
+				const ciw = {
+					actions: {
+						next() {
+							if (ciw.currentImageIndex === ciw.images.length - 1) {
+								return;
+							}
+							ciw.currentImageIndex++;
+							ciw.elements.loading.style.display = 'block';
+							ciw.elements.image.src = ciw.images[ciw.currentImageIndex];
+							ciw.updateNavState();
+						},
+						prev() {
+							if (ciw.currentImageIndex === 0) {
+								return;
+							}
+							ciw.currentImageIndex--;
+							ciw.elements.loading.style.display = 'block';
+							ciw.elements.image.src = ciw.images[ciw.currentImageIndex];
+							ciw.updateNavState();
+						},
+						downloadImages() {
+							if (!Array.isArray(ciw.images)) {
+								return;
+							}
+							const dl = document.createElement('a');
 
-				const next = () => {
-						if (currentImageIndex === images.length - 1) {
-							return;
+							ciw.images.forEach(imageUrl => {
+								dl.download = imageUrl.replace(/^.*[\\/]/, '');
+								dl.href = imageUrl;
+								dl.click();
+							});
+						},
+						printPage() {
+							ciw.elements.printContainer.innerHTML = '';
+
+							const imgs = ciw.images.map(imageUrl => {
+								const i = document.createElement('img');
+								i.src = imageUrl;
+								i.classList.add('print-image');
+								ciw.elements.printContainer.appendChild(i);
+								return i;
+							});
+
+							ciw._printIfLoaded(imgs).then(() => ciw.elements.printContainer.innerHTML = '');
 						}
-						currentImageIndex++;
-						img.src = images[currentImageIndex];
 					},
-					prev = () => {
-						if (currentImageIndex === 0) {
-							return;
-						}
-						currentImageIndex--;
-						img.src = images[currentImageIndex];
+					elements: {},
+					init() {
+						ciw.elements = [
+							'image',
+							'loading',
+							'prevImg',
+							'printContainer',
+							'nextImg',
+							'space'
+						].reduce((elements, id) => Object.assign(elements, { [id]: document.getElementById(id) }), {});
+						ciw.elements.image.onload = () => ciw.elements.loading.style.display = 'none';
+						window.dispatchEvent(new Event('ready', { bubbles: true }));
 					},
-
-					downloadImages = () => {
-						if (!images) {
-							return;
-						}
-						const dl = document.createElement('a');
-
-						images.forEach(imageUrl => {
-							dl.download = imageUrl.replace(/^.*[\\/]/, '');
-							dl.href = imageUrl;
-							dl.click();
-						});
-					},
-
-					_printIfLoaded = imgs => {
-						return new Promise((resolve, reject) => {
+					_printIfLoaded: imgs =>
+						new Promise((resolve, reject) => {
 							setTimeout(() => {
 								if (!imgs.every(i => i.complete)) {
-									_printIfLoaded(imgs);
+									ciw._printIfLoaded(imgs);
 									return;
 								}
 								print();
 								resolve();
 							}, 100);
-						});
+						}),
+					setImages(array, startIndex = 0) {
+						const imageUrl = array[startIndex],
+							actions = document.getElementById('actions'),
+							navs = document.querySelectorAll('.nav');
+						ciw.images = array;
+						ciw.elements.loading.style.display = 'block';
+						ciw.elements.image.src = imageUrl;
+						ciw.currentImageIndex = startIndex;
+
+						// hide/show actions
+						actions.hidden = ciw.images.length === 0 ? true : false;
+
+						navs.forEach(n => n.hidden = ciw.images.length > 1 ? false : true);
+						ciw.updateNavState();
 					},
-
-					printPage = () => {
-						const printContainer = document.querySelector('#printContainer');
-						let imgs;
-
-						printContainer.innerHTML = '';
-
-						imgs = images.map(imageUrl => {
-							const i = document.createElement('img');
-							i.src = imageUrl;
-							i.classList.add('print-image');
-							printContainer.appendChild(i);
-							return i;
-						});
-
-						_printIfLoaded(imgs).then(() => {
-							printContainer.innerHTML = '';
-						});
-					},
-
-					init = () => {
-						window.dispatchEvent(new Event('ready', { bubbles: true }));
-					};
-
-
-				window.setImages = (array, startIndex = 0) => {
-					const imageUrl = array[startIndex],
-						actions = document.querySelector('.actions'),
-						navs = document.querySelectorAll('.nav');
-					img = document.querySelector('#image');
-					images = array;
-					img.src = imageUrl;
-
-					// hide/show actions
-					actions.hidden = images.length === 0 ? true : false;
-					navs.forEach(n => n.hidden = images.length > 1 ? false : true);
+					updateNavState() {
+						if (ciw.currentImageIndex === 0) {
+							ciw.elements.prevImg.setAttribute('disabled', true);
+						} else {
+							ciw.elements.prevImg.removeAttribute('disabled');
+						}
+						if (ciw.currentImageIndex + 1 === ciw.images.length) {
+							ciw.elements.nextImg.setAttribute('disabled', true);
+						} else {
+							ciw.elements.nextImg.removeAttribute('disabled');
+						}
+						ciw.elements.space.innerHTML = `${ciw.currentImageIndex + 1} / ${ciw.images.length}`;
+					}
 				};
+				window.ciw = ciw;
 
-				init();
+				ciw.init();
 			</script>
 		</template>
 	</template>


### PR DESCRIPTION
- Use sans-serif font
- Disable (visibly) prev/next buttons at start/end
- Use a spinner while images are loading
- Refactor code into the "ciw" namespace
- Store element refs on init
- Support reusing old windows after refresh (actually fixes client issue)

Mostly addresses #32