### PR TITLE
(patch) calculate max zoom so the image covers at least half of the container

### DIFF
--- a/lib/reducers/pan-zoom.js
+++ b/lib/reducers/pan-zoom.js
@@ -1,4 +1,4 @@
-import { getBounded, getFitScale } from '../utils';
+import { getBounded, getFitScale, getCoverScale } from '../utils';
 
 const EMPTY = 'empty';
 const LOADING = 'loading';
@@ -16,10 +16,20 @@ const initState = {
 
 const maxZoomPixelRatio = 1.1;
 
-const maxZoomLevel = fitScale => maxZoomPixelRatio / fitScale;
+const maxZoomLevelByPixelRatio = fitScale => maxZoomPixelRatio / fitScale;
+const maxZoomLevelByCoverage = coverScale => 2 * coverScale;
 
-const getBoundedZoom = (zoom, fitScale) =>
-	getBounded(zoom, 1, maxZoomLevel(fitScale));
+const getBoundedZoom = (zoom, iw, ih, cw, ch) => {
+	// how much to scale the image so it fits in the container
+	const fitScale = getFitScale(iw, ih, cw, ch);
+
+	// how much to scale the *scaled-to-fit* image so it covers the container
+	const coverScale = getCoverScale(iw * fitScale, ih * fitScale, cw, ch);
+
+	// zoom until the image is displayed at 110% it's natural size or it covers half of the container
+	const maxZoom = Math.max(maxZoomLevelByPixelRatio(fitScale), maxZoomLevelByCoverage(coverScale));
+	return getBounded(zoom, 1, maxZoom);
+};
 
 const emptyReducer = (state, action) => {
 	switch (action.type) {
@@ -63,7 +73,7 @@ const loadedReducer = (state, action) => {
 			...state,
 			zoom: getBoundedZoom(
 				action.zoom,
-				getFitScale(state.iw, state.ih, state.cw, state.ch)
+				state.iw, state.ih, state.cw, state.ch
 			)
 		};
 	case 'zoomBy':
@@ -72,7 +82,7 @@ const loadedReducer = (state, action) => {
 			zoom: action.bounded
 				? getBoundedZoom(
 					state.zoom + action.delta,
-					getFitScale(state.iw, state.ih, state.cw, state.ch)
+					state.iw, state.ih, state.cw, state.ch
 				)
 				: Math.max(0.2, state.zoom + action.delta)
 		};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,6 +18,16 @@ export const getBounded = (val, min, max) => Math.max(min, Math.min(max, val));
 export const getFitScale = (iw, ih, cw, ch) => cw / ch < iw / ih ? cw / iw : ch / ih;
 
 /**
+ * Calculates the amount needed to scale an image so it covers a container.
+ * @param  {Number} iw image width
+ * @param  {Number} ih image height
+ * @param  {Number} cw container width
+ * @param  {Number} ch container height
+ * @return {Number}    amount to scale
+ */
+export const getCoverScale = (iw, ih, cw, ch) => cw / ch > iw / ih ? cw / iw : ch / ih;
+
+/**
  * Given an array of [x,y] points, it calculates the center point of those points.
  * @param  {Array[]}  arr the points
  * @return {Number[]}     the center points [x, y]


### PR DESCRIPTION
Fixes https://github.com/Neovici/cosmoz-image-viewer/issues/75