### PR TITLE
Fix Overlay -> Detached doesn't transition 

### DIFF
--- a/cosmoz-image-viewer-overlay.js
+++ b/cosmoz-image-viewer-overlay.js
@@ -20,7 +20,8 @@ class CosmozImageViewerOverlay extends mixinBehaviors([IronOverlayBehavior], Pol
 					on-track="_trackHandler" on-close-tapped="close"
 					images="[[images]]" sizing="contain"
 					credentials="[[credentials]]" current-image-index="[[currentImageIndex]]"
-					show-nav show-zoom show-close show-detach="[[showDetach]]" loop="[[loop]]">
+					show-nav show-zoom show-close show-detach="[[showDetach]]" loop="[[loop]]"
+					on-will-detach="_preventDetach">
 				</cosmoz-image-viewer>
 `;
 	}
@@ -62,6 +63,11 @@ class CosmozImageViewerOverlay extends mixinBehaviors([IronOverlayBehavior], Pol
 		if (e.detail.dy > window.innerHeight * 0.4) {
 			this.close();
 		}
+	}
+
+	_preventDetach(event) {
+		event.preventDefault();
+		this.dispatchEvent(new CustomEvent('detach-intent'));
 	}
 }
 window.customElements.define(CosmozImageViewerOverlay.is, CosmozImageViewerOverlay);

--- a/cosmoz-image-viewer-overlay.js
+++ b/cosmoz-image-viewer-overlay.js
@@ -19,7 +19,7 @@ class CosmozImageViewerOverlay extends mixinBehaviors([IronOverlayBehavior], Pol
 				<cosmoz-image-viewer
 					on-track="_trackHandler" on-close-tapped="close"
 					images="[[images]]" sizing="contain"
-					credentials="[[credentials]]" current-image-index="[[currentImageIndex]]"
+					credentials="[[credentials]]" current-image-index="{{currentImageIndex}}"
 					show-nav show-zoom show-close show-detach="[[showDetach]]" loop="[[loop]]"
 					on-will-detach="_preventDetach">
 				</cosmoz-image-viewer>
@@ -36,7 +36,8 @@ class CosmozImageViewerOverlay extends mixinBehaviors([IronOverlayBehavior], Pol
 				type: Array
 			},
 			currentImageIndex: {
-				type: Number
+				type: Number,
+				notify: true
 			},
 			showDetach: {
 				type: Boolean

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -408,7 +408,7 @@ class CosmozImageViewer extends translatable(mixinBehaviors([
 	detach() {
 		const detachPrevented = !this.dispatchEvent(new CustomEvent('will-detach', {cancelable: true}));
 		if (detachPrevented) {
-			return;
+			return false;
 		}
 
 		this._setIsDetached(true);
@@ -491,7 +491,11 @@ class CosmozImageViewer extends translatable(mixinBehaviors([
 	}
 
 	get hasWindow() {
-		return globals.window != null && !globals.window.closed && globals.window.ciw;
+		return globals.window != null && !globals.window.closed && !!globals.window.ciw;
+	}
+
+	get window() {
+		return globals.window;
 	}
 
 	syncState() {

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -312,7 +312,7 @@ class CosmozImageViewer extends translatable(mixinBehaviors([
 		this.removeEventListener('dblclick', this._dblClickListner);
 
 		if (imageOverlay) {
-			this._cleanupOverlayEvents();
+			this._setupDialogEvents(false);
 		}
 
 		this.cancelDebouncer('elementHeight');
@@ -363,13 +363,14 @@ class CosmozImageViewer extends translatable(mixinBehaviors([
 		dialog.images = this.images;
 		dialog.currentImageIndex = this.currentImageIndex;
 		dialog.open();
-		this._setupDialogEvents();
+		this._setupDialogEvents(true);
 	}
 
-	_setupDialogEvents() {
-		imageOverlay.addEventListener('current-image-index-changed', this._syncImageIndexBound);
-		imageOverlay.addEventListener('detach-intent', this._onOverlayDetachIntentBound);
-		imageOverlay.addEventListener('iron-overlay-closed', this._onOverlayClosedBound);
+	_setupDialogEvents(on) {
+		const f = (on ? imageOverlay.addEventListener : imageOverlay.removeEventListener).bind(imageOverlay);
+		f('current-image-index-changed', this._syncImageIndexBound);
+		f('detach-intent', this._onOverlayDetachIntentBound);
+		f('iron-overlay-closed', this._onOverlayClosedBound);
 	}
 
 	_syncImageIndex(event) {
@@ -382,13 +383,7 @@ class CosmozImageViewer extends translatable(mixinBehaviors([
 	}
 
 	_onOverlayClosed() {
-		this._cleanupOverlayEvents();
-	}
-
-	_cleanupOverlayEvents() {
-		imageOverlay.removeEventListener('current-image-index-changed', this._syncImageIndexBound);
-		imageOverlay.removeEventListener('detach-intent', this._onOverlayDetachIntentBound);
-		imageOverlay.removeEventListener('iron-overlay-closed', this._onOverlayClosedBound);
+		this._setupDialogEvents(false);
 	}
 
 	/**

--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -282,6 +282,7 @@ class CosmozImageViewer extends translatable(mixinBehaviors([
 
 	constructor() {
 		super();
+		this._syncImageIndexBound = this._syncImageIndex.bind(this);
 		this._onOverlayDetachIntentBound = this._onOverlayDetachIntent.bind(this);
 		this._onOverlayClosedBound = this._onOverlayClosed.bind(this);
 	}
@@ -366,8 +367,13 @@ class CosmozImageViewer extends translatable(mixinBehaviors([
 	}
 
 	_setupDialogEvents() {
+		imageOverlay.addEventListener('current-image-index-changed', this._syncImageIndexBound);
 		imageOverlay.addEventListener('detach-intent', this._onOverlayDetachIntentBound);
 		imageOverlay.addEventListener('iron-overlay-closed', this._onOverlayClosedBound);
+	}
+
+	_syncImageIndex(event) {
+		this.currentImageIndex = event.detail.value;
 	}
 
 	_onOverlayDetachIntent() {
@@ -380,6 +386,7 @@ class CosmozImageViewer extends translatable(mixinBehaviors([
 	}
 
 	_cleanupOverlayEvents() {
+		imageOverlay.removeEventListener('current-image-index-changed', this._syncImageIndexBound);
 		imageOverlay.removeEventListener('detach-intent', this._onOverlayDetachIntentBound);
 		imageOverlay.removeEventListener('iron-overlay-closed', this._onOverlayClosedBound);
 	}

--- a/test/detach.html
+++ b/test/detach.html
@@ -34,22 +34,23 @@
 		import { Base } from '@polymer/polymer/polymer-legacy';
 
 		sinon.assert.expose(chai.assert, { prefix: '' });
+		const createImageViewer = name => {
+			const el = fixture(name);
+
+			el.images = [
+				'../demo/images/stockholm.jpg',
+				'../demo/images/strasbourg.jpg',
+				'../demo/images/cosmos1.jpg'
+			];
+
+			return el;
+		};
 
 		suite('cosmoz-image-viewer', () => {
-			let imageViewer,
-				imageViewer2;
+			let imageViewer;
 
 			setup(function (done) {
-				imageViewer = fixture('cosmozImageViewer');
-				imageViewer2 = fixture('cosmozImageViewer2');
-
-				[imageViewer, imageViewer2].forEach(viewer => {
-					viewer.images = [
-						'../demo/images/stockholm.jpg',
-						'../demo/images/strasbourg.jpg',
-						'../demo/images/cosmos1.jpg'
-					];
-				});
+				imageViewer = createImageViewer('cosmozImageViewer');
 
 				const w = imageViewer.detach();
 				if (w == null) {
@@ -65,10 +66,13 @@
 				}, 100);
 			});
 
+			teardown(() => {
+				imageViewer.window.close();
+			});
+
 			test('detaching works', () => {
 				const w = imageViewer.detach();
 				assert.isNotNull(w);
-				w.close();
 			});
 
 			test('detaching to existing window works', () => {
@@ -76,15 +80,28 @@
 					w2 = imageViewer.detach();
 				assert.isNotNull(w);
 				assert.deepEqual(w, w2);
-				w.close();
 			});
 
 			test('shared detaching works', () => {
-				const w = imageViewer.detach(),
+				const imageViewer2 = createImageViewer('cosmozImageViewer2'),
+					w = imageViewer.detach(),
 					w2 = imageViewer2.detach();
 				assert.isNotNull(w);
 				assert.deepEqual(w, w2);
-				w.close();
+			});
+
+			test('detach from fullscreen works', () => {
+				assert.isFalse(imageViewer.hidden);
+				assert.isFalse(imageViewer.hasWindow);
+
+				imageViewer.openFullscreen();
+				assert.isFalse(imageViewer.hasWindow);
+
+				const ov = document.querySelector('cosmoz-image-viewer-overlay');
+
+				ov.shadowRoot.querySelector('cosmoz-image-viewer').detach();
+				assert.isTrue(imageViewer.hasWindow);
+				assert.isTrue(imageViewer.hidden);
 			});
 		});
 	</script>


### PR DESCRIPTION
Made the `detach` call cancelable (by canceling the `will-detach` event). Use this feature to prevent detaching the image viewer inside the overlay and instead call `detach` on the inline viewer.
Made the overlay and the inline viewer synchronize the displayed image index.
Added test for this behavior and did some minor cleanup of the rest of the detach tests.
Fixes https://github.com/Neovici/cosmoz-image-viewer/issues/76