### PR TITLE
fix: missing semantic release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ cosmoz-image-viewer
 
 [![Build Status](https://travis-ci.org/Neovici/cosmoz-image-viewer.svg?branch=master)](https://travis-ci.org/Neovici/cosmoz-image-viewer)
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/Neovici/cosmoz-image-viewer)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 # &lt;cosmoz-image-viewer&gt;
 


### PR DESCRIPTION
This should have been tagged as chore, but I want to force a patch release.