### PR TITLE
chore(ci): report coverage for master branch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test and report
         env:
           CC_TEST_REPORTER_ID: 48833ad27a301e5714aa1de8de7f8b8f0a662c12aceefab9cbc37d0a7e888a0e
-          GIT_BRANCH: ${{ github.ref }}
+          GIT_BRANCH: ${{ github.ref == 'refs/heads/master' && 'master' || github.ref }}
           GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           NEO_CC_URL: https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
           NEO_CC: ./cc-test-reporter


### PR DESCRIPTION
Seems like CC must report it on 'master' rather than 'refs/heads/master' to make reporting for the repo work properly.

![image](https://user-images.githubusercontent.com/960553/66747335-8f5f6c00-ee84-11e9-9bc1-b70cc710aa6b.png)
