### PR TITLE
fix: async jspdf loading

### DIFF
--- a/lib/pdf.js
+++ b/lib/pdf.js
@@ -1,6 +1,4 @@
 /* global jsPDF */
-import 'jspdf';
-
 export const fit = (rect, bounds) => {
 	const rectRatio = rect.width / rect.height,
 		boundsRatio = bounds.width / bounds.height;
@@ -20,7 +18,7 @@ export const create = async (urls, credentials) => {
 	const options = {
 			credentials: credentials ? 'include' : 'omit'
 		},
-		responses = (await Promise.all(urls.map(
+		[, ...responses] = await Promise.all([import('jspdf'), ...urls.map(
 			async url => {
 				const response = await fetch(url, options);
 				return response.ok
@@ -30,10 +28,10 @@ export const create = async (urls, credentials) => {
 					}
 					: undefined;
 			}
-		))).filter(Boolean),
+		)]),
 		pdf = new jsPDF(); // eslint-disable-line new-cap
 
-	responses.forEach(({
+	responses.filter(Boolean).forEach(({
 		url, data
 	}, i) => {
 		const


### PR DESCRIPTION
Fixes #80 
Adds async in parallel loading of `jspdf`.