### PR TITLE
fix: pinch state without useReducer

### DIFF
--- a/lib/hooks/use-pan-zoom.js
+++ b/lib/hooks/use-pan-zoom.js
@@ -7,9 +7,7 @@ import { useResize } from './use-resize';
 import {
 	getFitScale, calculateBounds
 } from '../utils';
-import {
-	usePinch, PINCHING
-} from './use-pinch';
+import { usePinch } from './use-pinch';
 import {
 	panZoomReducer, initState, ERROR
 } from '../reducers/pan-zoom';
@@ -80,8 +78,7 @@ const getStyle = (opts, zoom, panX, panY) => {
 				zoomBy(-Math.sign(event.deltaY) * 0.8);
 			}, [zoomBy, state.zoom]),
 
-			[pinchStatus, pinchDelta, startPinch] = usePinch(),
-			pinching = pinchStatus === PINCHING;
+			[pinching, pinchDelta, startPinch] = usePinch();
 
 		useEffect(() => pinchDelta !== 0 && zoomBy(pinchDelta * 0.01 * state.zoom, false), [pinchDelta, zoomBy]);
 		useEffect(() => !pinching && zoomBy(0), [pinching, zoomBy]);

--- a/lib/hooks/use-pinch.js
+++ b/lib/hooks/use-pinch.js
@@ -1,66 +1,50 @@
-import {
-	useEffect, useCallback, useReducer
-} from 'haunted';
-import {
-	pinchReducer, initState, PINCHING
-} from '../reducers/pinch';
+import { useEffect } from 'haunted';
+import { pinchReducer } from '../reducers/pinch';
 
-const getDistance = (ev1, ev2) => Math.hypot(ev2.pageX - ev1.pageX, ev2.pageY - ev1.pageY),
+const getDistance = (ev1, ev2) => Math.hypot(ev2.pageX - ev1.pageX, ev2.pageY - ev1.pageY);
 
-	/**
-	 * Tracks the amount a user pinched the document.
-	 *
-	 * Tracking is started by calling the `start` function.
-	 *
-	 * @return {Array} [status: string, delta: number, start: function]
-	 */
-	usePinch = () => {
-		const [state, dispatch] = useReducer(pinchReducer, initState),
+/**
+ * Tracks the amount a user pinched the document.
+ *
+ * Tracking is started by calling the `start` function.
+ *
+ * @return {Array} [isPinching: boolean, delta: number, start: function]
+ */
+export const usePinch = () => {
+	const pincher = pinchReducer(),
 
-			// TODO: handle variable number of touches a la use-touch-pan
-			start = useCallback(ev => {
-				if (ev.touches.length < 2) {
-					return;
-				}
-
-				dispatch({
-					type: 'start',
-					initialDistance: getDistance(...ev.touches)
-				});
-			}, [dispatch]),
-
-			pinch = useCallback(ev => {
-				dispatch({
-					type: 'pinch',
-					distance: getDistance(...ev.touches)
-				});
-			}, [dispatch]),
-
-			stop = useCallback(ev => {
-				if (ev.touches.length > 2) {
-					return;
-				}
-
-				dispatch({ type: 'stop' });
-			}, [dispatch]);
-
-		useEffect(() => {
-			if (state.status !== PINCHING) {
+		// TODO: handle variable number of touches a la use-touch-pan
+		start = ev => {
+			if (ev.touches.length < 2) {
 				return;
 			}
-			const opts = { passive: true };
 
-			document.addEventListener('touchmove', pinch, opts);
-			document.addEventListener('touchend', stop, opts);
-			return () => {
-				document.removeEventListener('touchmove', pinch, opts);
-				document.removeEventListener('touchend', stop, opts);
-			};
-		}, [state.status, stop, pinch]);
+			pincher.start(getDistance(...ev.touches));
+		},
 
-		return [state.status, state.delta, start];
-	};
+		pinch = ev => pincher.pinch(getDistance(...ev.touches)),
 
-export {
-	usePinch, PINCHING
+		stop = ev => {
+			if (ev.touches.length > 2) {
+				return;
+			}
+
+			pincher.stop();
+		};
+
+	useEffect(() => {
+		if (!pincher.isPinching) {
+			return;
+		}
+		const opts = { passive: true };
+
+		document.addEventListener('touchmove', pinch, opts);
+		document.addEventListener('touchend', stop, opts);
+		return () => {
+			document.removeEventListener('touchmove', pinch, opts);
+			document.removeEventListener('touchend', stop, opts);
+		};
+	}, [pincher.isPinching, stop, pinch]);
+
+	return [pincher.isPinching, pincher.state.delta, start];
 };

--- a/lib/reducers/pinch.js
+++ b/lib/reducers/pinch.js
@@ -1,43 +1,53 @@
-const INIT = 'init',
-	PINCHING = 'pinching',
+import { useState } from 'haunted';
 
+const
+	INIT = 'init',
+	PINCHING = 'pinching',
 	initState = {
 		status: INIT,
 		lastDistance: 0,
 		delta: 0
 	},
 
-	pinchReducer = (state, action) => {
-		switch (state.status) {
+	pinchReducer = () => {
+		const [state, setState] = useState(initState),
+			isPinching = state.status === PINCHING;
 
-		case INIT:
-			switch (action.type) {
-			case 'start':
-				return {
-					...state,
+		return {
+			state,
+			isPinching,
+
+			start(distance = 0) {
+				if (state.status !== INIT) {
+					return;
+				}
+				setState({
 					status: PINCHING,
-					lastDistance: action.initialDistance,
+					lastDistance: distance,
 					delta: 0
-				};
-			}
-			break;
+				});
+			},
 
-		case PINCHING:
-			switch (action.type) {
-			case 'stop':
-				return initState;
-			case 'pinch':
-				return {
-					...state,
-					delta: action.distance - state.lastDistance,
-					lastDistance: action.distance
-				};
-			}
-		}
+			stop() {
+				if (!isPinching) {
+					return;
+				}
+				setState(initState);
+			},
 
-		return state;
+			pinch(distance) {
+				if (!isPinching) {
+					return;
+				}
+				setState({
+					status: PINCHING,
+					lastDistance: distance,
+					delta: distance - state.lastDistance
+				});
+			}
+		};
 	};
 
 export {
-	pinchReducer, initState, INIT, PINCHING
+	pinchReducer
 };

--- a/test/hooks/use-pinch_test.js
+++ b/test/hooks/use-pinch_test.js
@@ -14,15 +14,15 @@ describe('use-pinch', () => {
 		const tag = 'use-pinch',
 
 			App = () => {
-				const [status, delta, start] = usePinch();
-				return html`<span @touchstart=${start}>${status}, ${delta}</span>`;
+				const [isPinching, delta, start] = usePinch();
+				return html`<span @touchstart=${start}>${isPinching}, ${delta}</span>`;
 			};
 
 		customElements.define(tag, component(App));
 
 		const teardown = attach(tag);
 		await cycle();
-		expect(text()).to.equal('init, 0', 'no touching');
+		expect(text()).to.equal('false, 0', 'no touching');
 
 		const target = host.firstChild.shadowRoot.firstElementChild;
 
@@ -31,7 +31,7 @@ describe('use-pinch', () => {
 			y: 10
 		}], target);
 		await cycle();
-		expect(text()).to.equal('init, 0', 'touch with one finger');
+		expect(text()).to.equal('false, 0', 'touch with one finger');
 
 		makeMultiTouchEvent('touchstart', [{
 			x: 10,
@@ -41,7 +41,7 @@ describe('use-pinch', () => {
 			y: 50
 		}], target);
 		await cycle();
-		expect(text()).to.equal('pinching, 0', 'touch with second finger');
+		expect(text()).to.equal('true, 0', 'touch with second finger');
 
 		makeMultiTouchEvent('touchmove', [{
 			x: 10,
@@ -51,21 +51,21 @@ describe('use-pinch', () => {
 			y: 100
 		}], document);
 		await cycle();
-		expect(text()).to.equal('pinching, 70.71067811865476', 'move second finger');
+		expect(text()).to.equal('true, 70.71067811865476', 'move second finger');
 
 		makeMultiTouchEvent('touchend', [{
 			x: 10,
 			y: 10
 		}], document);
 		await cycle();
-		expect(text()).to.equal('init, 0', 'raise one finger');
+		expect(text()).to.equal('false, 0', 'raise one finger');
 
 		makeMultiTouchEvent('touchmove', [{
 			x: 20,
 			y: 20
 		}], document);
 		await cycle();
-		expect(text()).to.equal('init, 0', 'move the finger');
+		expect(text()).to.equal('false, 0', 'move the finger');
 
 		makeMultiTouchEvent('touchstart', [{
 			x: 20,
@@ -75,7 +75,7 @@ describe('use-pinch', () => {
 			y: 30
 		}], target);
 		await cycle();
-		expect(text()).to.equal('pinching, 0', 'touch with second finger');
+		expect(text()).to.equal('true, 0', 'touch with second finger');
 
 		makeMultiTouchEvent('touchmove', [{
 			x: 20,
@@ -85,18 +85,18 @@ describe('use-pinch', () => {
 			y: 30
 		}], document);
 		await cycle();
-		expect(text()).to.equal('pinching, 10', 'move first finger');
+		expect(text()).to.equal('true, 10', 'move first finger');
 
 		makeMultiTouchEvent('touchend', [{
 			x: 20,
 			y: 30
 		}], document);
 		await cycle();
-		expect(text()).to.equal('init, 0', 'raise first finger');
+		expect(text()).to.equal('false, 0', 'raise first finger');
 
 		makeMultiTouchEvent('touchend', [], document);
 		await cycle();
-		expect(text()).to.equal('init, 0', 'raise second finger');
+		expect(text()).to.equal('false, 0', 'raise second finger');
 
 		teardown();
 	});


### PR DESCRIPTION
After Slack discussions around reducers I wanted to prototype another, less complex approach to the problem.

Switching from useReducer to a wrapped useState made the code a lot easier to read and maintain in my view.

1. There is no need for a reducing "dispatch" function or an "action" event with a loose contract. Each "action" can be a method of its own, with clear parameters/arguments and even JSDoc for better DevUX and obvious usage. The DevUX is also of course improved by things like intellisense for the methods and arguments.
2. #1 makes it easier to both read the core "reducer" and understand what it does and each method's parameters/context and output, but also the using layer since the methods/actions are more clear.
3. Going from a nested switch case to explicit status transition conditions in the methods makes the behavior a lot more obvious and the transitions (or preventing them) becomes a lot more expressive and clear.
4. Going from the reducer approach of "appending" to previous state to rather set a complete state (based on previous state or not) makes it easier to evaluate the outcome of an action in isolation since we don't have to care about the combination of actions/sub-states anymore.
5. The user doesn't really need anything else than the clean hook, so there's no need to export things like initState or status consts like PINCHING anymore.

Also, this pattern doesn't at this point provide a "stable" function dependency like "dispatch" so dropping the useCallback() pattern.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>