### PR TITLE
fix: maintain detached images and index if it's the same

### DIFF
--- a/cosmoz-image-viewer.html.js
+++ b/cosmoz-image-viewer.html.js
@@ -572,6 +572,11 @@ export const template = html`
 				}
 
 				setImages(images, currentImageIndex = 0) {
+					const prev = this.images,
+						isSame = prev != null && images.length === prev.length && images.every((img, i) => prev[i] === img);
+					if (isSame) {
+						return;
+					}
 					this.images = images;
 					this.currentImageIndex = currentImageIndex;
 				}


### PR DESCRIPTION
If we update a detached image view with an `images` array containing the same images than it should maintain position and perform no reload.