### PR TITLE
feat: support copyable text layers in image viewer

### DIFF
--- a/cosmoz-image-viewer.js
+++ b/cosmoz-image-viewer.js
@@ -172,6 +172,7 @@ const renderCosmozImageViewer = ({
 							.images="${host.images}"
 							.pdf="${host.pdf}"
 							.pdfOptions="${host.pdfOptions}"
+							.textLayers=${host.textLayers}
 							show-nav
 							show-zoom
 							show-close

--- a/lib/haunted-pan-zoom.js
+++ b/lib/haunted-pan-zoom.js
@@ -1,4 +1,3 @@
- 
 import { useImperativeApi } from '@neovici/cosmoz-utils/hooks/use-imperative-api';
 import { component, useCallback, useEffect } from '@pionjs/pion';
 import { html, nothing } from 'lit-html';
@@ -7,11 +6,18 @@ import { styleMap } from 'lit-html/directives/style-map.js';
 import { useDispatchEvent } from './hooks/use-dispatch-event';
 import { ERROR, usePanZoom } from './hooks/use-pan-zoom';
 
- 
-const HauntedPanZoom = ({ src, disabled, panStiffness, zoomStiffness }) => {
+const HauntedPanZoom = ({
+	src,
+	disabled,
+	panStiffness,
+	zoomStiffness,
+	overlay,
+}) => {
 	const {
 		status,
 		zoom,
+		iw,
+		ih,
 		load,
 		error,
 		zoomTo,
@@ -24,6 +30,12 @@ const HauntedPanZoom = ({ src, disabled, panStiffness, zoomStiffness }) => {
 		style,
 		containerRef,
 	} = usePanZoom(panStiffness, zoomStiffness);
+	const overlayStyle = {
+		...style,
+		width: `${iw || 0}px`,
+		height: `${ih || 0}px`,
+		pointerEvents: disabled ? 'auto' : 'none',
+	};
 
 	// trigger load transition when src changes
 	useEffect(load, [src]);
@@ -78,7 +90,7 @@ const HauntedPanZoom = ({ src, disabled, panStiffness, zoomStiffness }) => {
 		</style>
 		<div
 			class="container ${status}"
-			style="pointer-events: ${disabled ? 'none' : 'all'}"
+			style="pointer-events: ${disabled && !overlay ? 'none' : 'all'}"
 			@wheel=${onWheel}
 			${ref((el) => (containerRef.current = el))}
 		>
@@ -94,7 +106,12 @@ const HauntedPanZoom = ({ src, disabled, panStiffness, zoomStiffness }) => {
 							@error=${error}
 							style=${styleMap(style)}
 						/>
-				  `}
+						${overlay
+							? html`<div class="overlay" style=${styleMap(overlayStyle)}>
+									${overlay}
+								</div>`
+							: nothing}
+					`}
 		</div>
 	`;
 };

--- a/lib/hooks/use-cosmoz-image-viewer.js
+++ b/lib/hooks/use-cosmoz-image-viewer.js
@@ -24,24 +24,67 @@ const onImageError = (e) => {
 		e.currentTarget.setAttribute('hidden', true);
 	},
 	onStatusChanged = (ev) => ev.detail.value === 'error' && onImageError(ev),
-	renderImage = ({ src$, showZoom, isZoomed, _onZoomChanged }) => {
+	textRegionToCss = ({ top, left, width, height }) =>
+		[
+			['top', top],
+			['left', left],
+			['width', width],
+			['height', height],
+		]
+			.map(([prop, value]) => `${prop}: ${value}%`)
+			.join(';'),
+	renderTextRegion = (region) =>
+		html`<svg
+			class="word"
+			style="position:absolute;${textRegionToCss(region)}"
+			viewBox=${`0 0 ${region.viewBoxWidth} ${region.viewBoxHeight}`}
+			preserveAspectRatio="none"
+		>
+			<text
+				y="82%"
+				textLength="100%"
+				lengthAdjust="spacingAndGlyphs"
+				font-size=${Math.max(region.viewBoxHeight * 0.85, 0.01)}
+				style="fill: rgba(0, 0, 0, 0.01); user-select: text; -webkit-user-select: text;"
+			>
+				${region.content}
+			</text>
+		</svg>`,
+	renderTextLayer = (textLayer = []) => {
+		if (!textLayer.length) {
+			return nothing;
+		}
+
+		return html`<div
+			class="text-layer"
+			style="position:absolute;inset:0;user-select:text;-webkit-user-select:text"
+		>
+			${textLayer.map(renderTextRegion)}
+		</div>`;
+	},
+	renderImage = ({ src$, showZoom, isZoomed, _onZoomChanged, textLayer }) => {
 		const src = guard(src$, () => until(src$));
+		const overlay = renderTextLayer(textLayer);
 
 		return [
 			showZoom
 				? html`<haunted-pan-zoom
 						class="image-zoom"
 						.src=${src}
+						.overlay=${overlay}
 						?disabled=${!isZoomed}
 						@zoom-changed=${_onZoomChanged}
 						@status-changed=${onStatusChanged}
 					></haunted-pan-zoom>`
-				: html`<img
-						class="image"
-						.src=${src}
-						style="width:100%"
-						@error=${onImageError}
-					/>`,
+				: html`<div style="position:relative;width:100%;line-height:0;">
+						<img
+							class="image"
+							.src=${src}
+							style="width:100%"
+							@error=${onImageError}
+						/>
+						${overlay}
+					</div>`,
 			guard(src$, () =>
 				until(
 					src$.then(() => nothing),
@@ -106,6 +149,7 @@ const onImageError = (e) => {
 				images: rawImages = empty,
 				pdf: pdfUrl,
 				pdfOptions,
+				textLayers = empty,
 				showZoom,
 				title,
 				downloadFileName = 'archive',
@@ -113,18 +157,27 @@ const onImageError = (e) => {
 				detachedShowZoom,
 			} = host,
 			images = usePdfImages(pdfUrl, pdfOptions, rawImages),
+			slides = useMemo(
+				() =>
+					images.map((image, index) => ({
+						image,
+						textLayer: textLayers[index] ?? empty,
+					})),
+				[images, textLayers],
+			),
 			[isZoomed, setIsZoomed] = useState(false),
 			_onZoomChanged = (ev) => setIsZoomed(ev.detail.value > 1),
 			_invoke = useMemo(
 				() => memoize((image) => Promise.resolve(invoke(image))),
 				[],
 			),
-			{ slide, next, prev, goto, index, first, last } = useSlideList(images, {
+			{ slide, next, prev, goto, index, first, last } = useSlideList(slides, {
 				loop,
-				initial: images?.[host.currentImageIndex],
-				render: (image) =>
+				initial: slides?.[host.currentImageIndex],
+				render: ({ image, textLayer }) =>
 					render({
 						src$: _invoke(image),
+						textLayer,
 						showZoom,
 						isZoomed,
 						_onZoomChanged,
@@ -139,6 +192,7 @@ const onImageError = (e) => {
 				() =>
 					popout({
 						images,
+						textLayers,
 						index,
 						title,
 						loop,
@@ -147,7 +201,15 @@ const onImageError = (e) => {
 						onDetach: () => setDetached(true),
 						onClose: () => setDetached(false),
 					}),
-				[images, index, title, loop],
+				[
+					images,
+					textLayers,
+					index,
+					title,
+					loop,
+					syncImageIndex,
+					detachedShowZoom,
+				],
 			),
 			syncState = useCallback(() => {
 				if (!hasWindow) return;

--- a/lib/popout.js
+++ b/lib/popout.js
@@ -10,6 +10,7 @@ export let hasWindow = false;
 
 export const popout = ({
 	images,
+	textLayers,
 	index,
 	syncImageIndex,
 	title,
@@ -35,6 +36,7 @@ export const popout = ({
 			<cosmoz-image-viewer
 				fullscreen
 				.images="${images}"
+				.textLayers=${textLayers}
 				.currentImageIndex=${index}
 				@current-image-index-changed=${syncImageIndex}
 				show-nav

--- a/test/text-layer.test.js
+++ b/test/text-layer.test.js
@@ -1,0 +1,57 @@
+import '../cosmoz-image-viewer.js';
+
+import { perform } from '@neovici/cfg/web/perform.js';
+import { fixture, html } from '@open-wc/testing';
+import { absolute, ignoreResizeLoopError } from './helpers/index.js';
+
+const textLayers = [
+	[
+		{
+			id: 'word-1',
+			content: 'Selectable',
+			top: 10,
+			left: 10,
+			width: 25,
+			height: 8,
+			viewBoxWidth: 100,
+			viewBoxHeight: 30,
+		},
+	],
+];
+
+suite('cosmoz-image-viewer text layers', () => {
+	suiteSetup(ignoreResizeLoopError);
+
+	test('renders text layers in the main viewer and detached popup', async () => {
+		await fixture(
+			html`<cosmoz-image-viewer
+				show-nav
+				show-page-number
+				show-detach
+				.images=${[absolute('/stories/images/stockholm.jpg')]}
+				.textLayers=${textLayers}
+			></cosmoz-image-viewer>`,
+		);
+
+		await perform(async ({ page, expect }) => {
+			await expect(page.locator('cosmoz-image-viewer svg.word')).toHaveCount(1);
+			await expect(
+				page.locator('cosmoz-image-viewer svg.word text'),
+			).toContainText('Selectable');
+
+			await page.locator('cosmoz-image-viewer').hover();
+			const popupPromise = page.waitForEvent('popup');
+			await page
+				.locator('button[title="Detach image to separate window"]')
+				.click();
+			const popup = await popupPromise;
+
+			await expect(popup.locator('cosmoz-image-viewer svg.word')).toHaveCount(
+				1,
+			);
+			await expect(
+				popup.locator('cosmoz-image-viewer svg.word text'),
+			).toContainText('Selectable');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
Add optional text layer support to `cosmoz-image-viewer` so callers can overlay selectable OCR words without losing existing viewer behavior.

## Changes
- forward `textLayers` through fullscreen and detached viewer flows
- render selectable text overlays in both regular and zoomed image modes
- add a focused regression test covering main-view and popup rendering

## Validation
- `npm exec -- wtr --files test/text-layer.test.js`
