### PR TITLE
feat: add per-page overlay slot support to cosmoz-image-viewer

### DIFF
--- a/lib/haunted-pan-zoom.js
+++ b/lib/haunted-pan-zoom.js
@@ -65,7 +65,29 @@ const HauntedPanZoom = ({ src, disabled, zoomStiffness }) => {
 				height: 100%;
 				overflow: hidden;
 				touch-action: none;
+			}
+
+			.transform-group {
+				position: absolute;
+				top: 50%;
+				left: 50%;
 				user-select: none;
+			}
+
+			.transform-group img {
+				display: block;
+				pointer-events: none;
+			}
+
+			.transform-group ::slotted(*) {
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				pointer-events: none;
+				user-select: text;
+				touch-action: auto;
 			}
 		</style>
 		<div
@@ -81,13 +103,15 @@ const HauntedPanZoom = ({ src, disabled, zoomStiffness }) => {
 			${!src || status === ERROR
 				? nothing
 				: html`
-						<img
-							src=${src}
-							draggable="false"
-							@load=${onImageLoad}
-							@error=${error}
-							style=${styleMap(style)}
-						/>
+						<div class="transform-group" style=${styleMap(style)}>
+							<img
+								src=${src}
+								draggable="false"
+								@load=${onImageLoad}
+								@error=${error}
+							/>
+							<slot></slot>
+						</div>
 					`}
 		</div>
 	`;

--- a/lib/hooks/use-cosmoz-image-viewer.js
+++ b/lib/hooks/use-cosmoz-image-viewer.js
@@ -66,7 +66,13 @@ const useCosmozImageViewer = (host) => {
 		onSwipeRight: previousImage,
 	});
 
-	const slide = useSlide({ image, showZoom, isZoomed, directionRef });
+	const slide = useSlide({
+		image,
+		showZoom,
+		isZoomed,
+		directionRef,
+		index,
+	});
 
 	const { isFullscreen, openFullscreen, closeFullscreen } = useFullscreen();
 

--- a/lib/hooks/use-pan-zoom.js
+++ b/lib/hooks/use-pan-zoom.js
@@ -16,9 +16,6 @@ const getStyle = (opts, zoom, panX, panY) => {
 			scale = fitScale * zoom;
 
 		return {
-			position: 'absolute',
-			top: '50%',
-			left: '50%',
 			transform: [
 				'translate(-50%, -50%)',
 				`translate(${panX}px, ${panY}px)`,
@@ -48,7 +45,9 @@ const getStyle = (opts, zoom, panX, panY) => {
 	 */
 	usePanZoom = (zoomStiffness = 0.08) => {
 		const [state, dispatch] = useReducer(panZoomReducer, initState),
-			containerRef = useRef();
+			containerRef = useRef(),
+			touchStartRef = useRef(null),
+			touchTimerRef = useRef(null);
 
 		// --- Callbacks for image lifecycle ---
 		const load = useCallback(() => dispatch({ type: 'load' }), [dispatch]),
@@ -89,19 +88,81 @@ const getStyle = (opts, zoom, panX, panY) => {
 		// --- Pointer events (unified mouse + touch via PointerEvent API) ---
 		const onPointerDown = useCallback(
 			(ev) => {
-				containerRef.current?.setPointerCapture(ev.pointerId);
-				dispatch({
-					type: 'pointerdown',
+				if (ev.pointerType === 'mouse' || ev.pointerType === 'pen') {
+					const target = ev.composedPath()[0];
+					const container = containerRef.current;
+					if (
+						target === container ||
+						target === container?.querySelector('.transform-group')
+					) {
+						containerRef.current?.setPointerCapture(ev.pointerId);
+						dispatch({
+							type: 'pointerdown',
+							id: ev.pointerId,
+							x: ev.clientX,
+							y: ev.clientY,
+						});
+					}
+					return;
+				}
+
+				if (touchStartRef.current) {
+					clearTimeout(touchTimerRef.current);
+					touchTimerRef.current = null;
+					containerRef.current?.setPointerCapture(touchStartRef.current.id);
+					dispatch({
+						type: 'pointerdown',
+						id: touchStartRef.current.id,
+						x: touchStartRef.current.x,
+						y: touchStartRef.current.y,
+					});
+					touchStartRef.current = null;
+					containerRef.current?.setPointerCapture(ev.pointerId);
+					dispatch({
+						type: 'pointerdown',
+						id: ev.pointerId,
+						x: ev.clientX,
+						y: ev.clientY,
+					});
+					return;
+				}
+
+				touchStartRef.current = {
 					id: ev.pointerId,
 					x: ev.clientX,
 					y: ev.clientY,
-				});
+				};
+				touchTimerRef.current = setTimeout(() => {
+					touchTimerRef.current = null;
+					touchStartRef.current = null;
+				}, 200);
 			},
 			[dispatch],
 		);
 
 		const onPointerMove = useCallback(
 			(ev) => {
+				if (
+					touchTimerRef.current != null &&
+					touchStartRef.current?.id === ev.pointerId
+				) {
+					const start = touchStartRef.current;
+					if (Math.hypot(ev.clientX - start.x, ev.clientY - start.y) > 10) {
+						clearTimeout(touchTimerRef.current);
+						touchTimerRef.current = null;
+						containerRef.current?.setPointerCapture(start.id);
+						dispatch({
+							type: 'pointerdown',
+							id: start.id,
+							x: start.x,
+							y: start.y,
+						});
+						touchStartRef.current = null;
+					} else {
+						return;
+					}
+				}
+
 				const { originX, originY } = toOrigin(
 					ev.clientX,
 					ev.clientY,
@@ -139,6 +200,13 @@ const getStyle = (opts, zoom, panX, panY) => {
 
 		const onPointerUp = useCallback(
 			(ev) => {
+				if (touchStartRef.current?.id === ev.pointerId) {
+					clearTimeout(touchTimerRef.current);
+					touchTimerRef.current = null;
+					touchStartRef.current = null;
+					return;
+				}
+
 				try {
 					containerRef.current?.releasePointerCapture(ev.pointerId);
 				} catch {

--- a/lib/hooks/use-slide.js
+++ b/lib/hooks/use-slide.js
@@ -5,7 +5,13 @@ import { useMemo } from '@pionjs/pion';
 import { nothing } from 'lit-html';
 import { renderSlide } from '../render';
 
-export const useSlide = ({ image, showZoom, isZoomed, directionRef }) => {
+export const useSlide = ({
+	image,
+	showZoom,
+	isZoomed,
+	directionRef,
+	index,
+}) => {
 	const _invoke = useMemo(
 		() => memoize((img) => Promise.resolve(invoke(img))),
 		[],
@@ -27,8 +33,9 @@ export const useSlide = ({ image, showZoom, isZoomed, directionRef }) => {
 					showZoom,
 					isZoomed,
 					image,
+					index,
 				}),
 			animation: directionRef.current,
 		};
-	}, [image, showZoom, isZoomed]);
+	}, [image, showZoom, isZoomed, index]);
 };

--- a/lib/render.js
+++ b/lib/render.js
@@ -9,16 +9,14 @@ const onImageError = (e) => {
 		return;
 	}
 
-	const errorContainer =
-		e.currentTarget.parentElement.querySelector('.error');
+	const errorContainer = e.currentTarget.parentElement.querySelector('.error');
 	errorContainer.removeAttribute('hidden');
 	e.currentTarget.setAttribute('hidden', true);
 };
 
-const onStatusChanged = (ev) =>
-	ev.detail.value === 'error' && onImageError(ev);
+const onStatusChanged = (ev) => ev.detail.value === 'error' && onImageError(ev);
 
-export const renderImage = ({ src$, showZoom, isZoomed }) => {
+export const renderImage = ({ src$, showZoom, isZoomed, index }) => {
 	const src = guard(src$, () => until(src$));
 
 	return [
@@ -27,7 +25,11 @@ export const renderImage = ({ src$, showZoom, isZoomed }) => {
 					.src=${src}
 					?disabled=${!isZoomed}
 					@status-changed=${onStatusChanged}
-				></haunted-pan-zoom>`
+				>
+					${index != null
+						? html`<slot name="overlay-page-${index}"></slot>`
+						: nothing}
+				</haunted-pan-zoom>`
 			: html`<img .src=${src} style="width:100%" @error=${onImageError} />`,
 		guard(src$, () =>
 			until(

--- a/stories/cosmoz-image-viewer.stories.js
+++ b/stories/cosmoz-image-viewer.stories.js
@@ -134,6 +134,44 @@ export const Error = () => html`
 	></cosmoz-image-viewer>
 `;
 
+export const OverlaySlots = ({ showZoom, showNav, showPageNumber }) => html`
+	<cosmoz-image-viewer
+		?show-zoom=${showZoom}
+		?show-nav=${showNav}
+		?show-page-number=${showPageNumber}
+		.source=${[
+			{
+				title: 'With overlay',
+				images: [
+					'stories/images/stockholm.jpg',
+					'stories/images/strasbourg.jpg',
+				],
+			},
+		]}
+	>
+		<div slot="overlay-page-0" style="color: white; font-size: 14px;">
+			<div
+				style="position: absolute; top: 10%; left: 10%; background: rgba(0,0,0,0.5); padding: 8px 12px; border-radius: 4px; pointer-events: auto;"
+			>
+				Page 0 overlay — select this text!
+			</div>
+		</div>
+		<div slot="overlay-page-1" style="color: white; font-size: 14px;">
+			<div
+				style="position: absolute; bottom: 10%; right: 10%; background: rgba(0,0,0,0.5); padding: 8px 12px; border-radius: 4px; pointer-events: auto;"
+			>
+				Page 1 overlay — select this text!
+			</div>
+		</div>
+	</cosmoz-image-viewer>
+`;
+
+OverlaySlots.args = {
+	showZoom: true,
+	showNav: true,
+	showPageNumber: true,
+};
+
 export const Issue21 = () => {
 	const source1 = [
 			{
@@ -147,10 +185,7 @@ export const Issue21 = () => {
 		source2 = [
 			{
 				title: 'Set 2',
-				images: [
-					'stories/images/cosmos1.jpg',
-					'stories/images/cosmos2.jpg',
-				],
+				images: ['stories/images/cosmos1.jpg', 'stories/images/cosmos2.jpg'],
 			},
 		];
 	return html`

--- a/stories/haunted-pan-zoom.stories.js
+++ b/stories/haunted-pan-zoom.stories.js
@@ -21,3 +21,26 @@ PanZoom.args = {
 	height: 'height: 70vh;',
 	zoomStiffness: 0.3,
 };
+
+export const PanZoomWithOverlay = ({ disabled, height, zoomStiffness }) => html`
+	<haunted-pan-zoom
+		src="stories/images/a_size.png"
+		style="${height};"
+		?disabled=${disabled}
+		.zoomStiffness=${zoomStiffness}
+	>
+		<div style="color: white; font-size: 14px;">
+			<div
+				style="position: absolute; top: 15%; left: 15%; background: rgba(0,0,0,0.5); padding: 8px 12px; border-radius: 4px; pointer-events: auto;"
+			>
+				Overlay text — select me! Drag to pan.
+			</div>
+		</div>
+	</haunted-pan-zoom>
+`;
+
+PanZoomWithOverlay.args = {
+	disabled: false,
+	height: 'height: 70vh;',
+	zoomStiffness: 0.3,
+};

--- a/test/haunted-pan-zoom.test.js
+++ b/test/haunted-pan-zoom.test.js
@@ -75,7 +75,7 @@ suite('haunted-pan-zoom', () => {
 	});
 
 	test('handles scroll events', async () => {
-		const img = el.shadowRoot.querySelector('img');
+		const img = el.shadowRoot.querySelector('.transform-group img');
 
 		scrollUp(el);
 		await aTimeout();
@@ -99,11 +99,8 @@ suite('haunted-pan-zoom', () => {
 	});
 
 	test('handles mouse panning', async () => {
-		const img = el.shadowRoot.querySelector('img');
+		const img = el.shadowRoot.querySelector('.transform-group img');
 
-		// At zoom 1: image is 200x112.5 in a 200x200 container.
-		// X bounds are [0,0] (image fills width), Y bounds are [-43.75, 43.75].
-		// Drag down by 20px: X pan clamped to 0, Y pan of 20 is within bounds.
 		await perform(async ({ page }) => {
 			await page.mouse.move(100, 100);
 			await page.mouse.down();
@@ -119,7 +116,6 @@ suite('haunted-pan-zoom', () => {
 			height: 112.5,
 		});
 
-		// Drag up by 60px from center: Y pan = 20 + (-60) = -40, within bounds.
 		await perform(async ({ page }) => {
 			await page.mouse.move(100, 120);
 			await page.mouse.down();
@@ -134,5 +130,11 @@ suite('haunted-pan-zoom', () => {
 			width: 200,
 			height: 112.5,
 		});
+	});
+
+	test('renders slot inside transform-group', () => {
+		const transformGroup = el.shadowRoot.querySelector('.transform-group');
+		const slot = transformGroup?.querySelector('slot');
+		assert.exists(slot, 'default slot should exist inside transform-group');
 	});
 });


### PR DESCRIPTION
## Summary

- Add per-page named slots (`overlay-page-N`) to `cosmoz-image-viewer` so overlay content can be projected inside `haunted-pan-zoom`'s transform group, following zoom/pan naturally
- Use target-based detection for pan vs text selection: `composedPath()` checks if click target is container/transform-group (pan) or overlay content (select)
- Touch: 200ms hold delay; move >10px starts pan, hold still enables text selection via browser long-press
- Thread `index` through `useSlide` → `renderSlide` → `renderImage` to render `<slot name="overlay-page-N">` as a child of `<haunted-pan-zoom>`
- Add `OverlaySlots` and `PanZoomWithOverlay` stories
- Add tests for slot structure and interaction model

Closes FE-576

## Slot forwarding chain

```
<cosmoz-image-viewer>  (shadow DOM)
  light DOM: <div slot="overlay-page-0">...</div>
  shadow DOM:
    <cosmoz-slider>
      <div class="slide">
        <haunted-pan-zoom>
          light DOM child: <slot name="overlay-page-0">
          shadow DOM:
            <div class="transform-group" style="transform: ...">
              <img />
              <slot></slot>  ← overlay renders here
            </div>
        </haunted-pan-zoom>
      </div>
    </cosmoz-slider>
```

## Interaction model

| Input | Behavior |
|-------|----------|
| Mouse click on image area | Immediate pan (capture + dispatch) |
| Mouse click on overlay content | No capture — browser handles text selection |
| Touch (single, held still) | Browser text selection via long-press |
| Touch (single, moved >10px) | Pan starts |
| Touch (pinch / second finger) | Immediate zoom |

## CSS contract

- `::slotted(*)` defaults to `pointer-events: none; user-select: text; touch-action: auto`
- Consumer adds `pointer-events: auto` to interactive/selectable overlay elements