### PR TITLE
feat: add overlay slot support for non-zoom mode

### DIFF
--- a/cosmoz-image-viewer.style.js
+++ b/cosmoz-image-viewer.style.js
@@ -168,6 +168,23 @@ img {
     overflow: visible;
 }
 
+.image-container {
+    position: relative;
+}
+
+.image-container img {
+    width: 100%;
+    display: block;
+}
+
+.image-container ::slotted(*) {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
 haunted-pan-zoom {
     flex: auto;
     display: flex;

--- a/lib/render.js
+++ b/lib/render.js
@@ -30,7 +30,12 @@ export const renderImage = ({ src$, showZoom, isZoomed, index }) => {
 						? html`<slot name="overlay-page-${index}"></slot>`
 						: nothing}
 				</haunted-pan-zoom>`
-			: html`<img .src=${src} style="width:100%" @error=${onImageError} />`,
+			: html`<div class="image-container">
+					<img .src=${src} @error=${onImageError} />
+					${index != null
+						? html`<slot name="overlay-page-${index}"></slot>`
+						: nothing}
+				</div>`,
 		guard(src$, () =>
 			until(
 				src$.then(() => nothing),


### PR DESCRIPTION
## Summary

- Add overlay slot support when `showZoom=false` by wrapping the image in a `.image-container` div with the overlay slot
- Overlay content can now be projected over images in both zoom and non-zoom modes
- Non-zoom overlays have `pointer-events` enabled by default (no pan/zoom to interfere)

## Changes

- `lib/render.js`: Wrap non-zoom `<img>` in `.image-container` div with `<slot name="overlay-page-${index}">`
- `cosmoz-image-viewer.style.js`: Add CSS for `.image-container` with relative positioning and absolute overlay positioning

## Usage

```html
<cosmoz-image-viewer .source=${files}>
  <div slot="overlay-page-0" style="position: absolute; top: 10%; left: 10%;">
    Overlay content here
  </div>
</cosmoz-image-viewer>
```

Works with or without `showZoom`.