### PR TITLE
fix: image gets selected when you try to select text in an overlay

### DIFF
--- a/cosmoz-image-viewer.style.js
+++ b/cosmoz-image-viewer.style.js
@@ -175,6 +175,7 @@ img {
 .image-container img {
     width: 100%;
     display: block;
+    user-select: none;
 }
 
 .image-container ::slotted(*) {


### PR DESCRIPTION
## Summary

Add `user-select: none` to `.image-container img` to prevent text selection on the image in non-zoom mode, matching the zoom mode behavior where `.transform-group` has `user-select: none`.

## Changes

- Add `user-select: none;` to `.image-container img` in `cosmoz-image-viewer.style.js`