### PR TITLE
fix: loop navigation bug and add page count to detached viewer

### DIFF
--- a/lib/hooks/use-image-navigation.js
+++ b/lib/hooks/use-image-navigation.js
@@ -29,9 +29,7 @@ export const useImageNavigation = ({
 	const first = !loop && safeFileIndex === 0 && index <= 0;
 
 	const last =
-		!loop &&
-		safeFileIndex === files.length - 1 &&
-		index >= images.length - 1;
+		!loop && safeFileIndex === files.length - 1 && index >= images.length - 1;
 
 	const gotoLastRef = useRef(false);
 
@@ -54,10 +52,14 @@ export const useImageNavigation = ({
 		}
 		const prevIdx = findFileIndex(files, safeFileIndex, -1, loop);
 		if (prevIdx != null) {
-			gotoLastRef.current = true;
-			setFileIndex(prevIdx);
+			if (prevIdx === safeFileIndex) {
+				setImageIndex(images.length - 1);
+			} else {
+				gotoLastRef.current = true;
+				setFileIndex(prevIdx);
+			}
 		}
-	}, [index, files, safeFileIndex, loop]);
+	}, [index, files, safeFileIndex, loop, images.length]);
 
 	useEffect(() => {
 		if (images.length === 0) return;

--- a/lib/popout-entry.js
+++ b/lib/popout-entry.js
@@ -37,6 +37,7 @@ if (state) {
 			@current-file-index-changed=${(e) =>
 				window.__popoutSync.fileIndex(e.detail.value)}
 			show-nav
+			show-page-number
 			?show-zoom=${state.detachedShowZoom}
 			show-close
 			?loop=${state.loop}


### PR DESCRIPTION
## Summary
- Fixes FE-597: Loop navigation bug with single file
- Fixes FE-603: Add page count to detached viewer

## Changes

### FE-597: Fix loop navigation with single file
When clicking previous on the first page of a single file with `loop=true`, the viewer now correctly navigates to the last image. The previous implementation relied on `gotoLastRef` which only triggered when the file index changed - but with a single file, the index stays the same.

**Fix:** When the previous file index equals the current file index (same file loop), directly set the image index to the last image instead of relying on the effect.

### FE-603: Add page count to detached viewer
The detached/popup viewer was missing the page count indicator. Added `show-page-number` attribute to the `<cosmoz-image-viewer>` in `popout-entry.js`.