### PR TITLE
feat: replace @neovici/cosmoz-i18next with i18next direct dependency

### DIFF
--- a/lib/popout.js
+++ b/lib/popout.js
@@ -1,4 +1,4 @@
-import { _ } from '@neovici/cosmoz-i18next';
+import { t } from 'i18next';
 
 let entryUrl;
 const getEntryUrl = async () =>
@@ -28,7 +28,7 @@ const openPopupHtml = (
 <html>
 <head>
 	<style>html { background: #000; }</style>
-	<title>${title ?? _('Cosmoz image viewer')}</title>
+	<title>${title ?? t('Cosmoz image viewer')}</title>
 </head>
 <body>
 	<script type="module" src="${entryUrl}"></script>

--- a/lib/render-viewer.js
+++ b/lib/render-viewer.js
@@ -1,6 +1,6 @@
-import { _ } from '@neovici/cosmoz-i18next';
 import { portal } from '@neovici/cosmoz-utils/directives/portal';
 import { html, lift } from '@pionjs/pion';
+import { t } from 'i18next';
 import { when } from 'lit-html/directives/when.js';
 
 import { close as closeIcon } from './icons/close';
@@ -20,7 +20,7 @@ export const renderLoading = () =>
 
 export const renderError = (error) =>
 	html`<div class="error">
-		<h2>${_('Failed to load files.')}</h2>
+		<h2>${t('Failed to load files.')}</h2>
 		<div class="desc">${error?.message ?? error}</div>
 	</div>`;
 
@@ -45,12 +45,7 @@ export const renderNavButtons = ({
 			>
 				${leftArrow}
 			</button>
-			<button
-				class="nav"
-				name="next"
-				?disabled=${last}
-				@click=${nextImage}
-			>
+			<button class="nav" name="next" ?disabled=${last} @click=${nextImage}>
 				${rightArrow}
 			</button>
 		`,
@@ -83,7 +78,7 @@ export const renderZoomButton = ({ showZoom, total, isZoomed, toggleZoom }) =>
 						.getRootNode()
 						.querySelector('haunted-pan-zoom')
 						.zoomTo(toggleZoom())}
-				title="${_('Zoom image')}"
+				title="${t('Zoom image')}"
 			>
 				${getZoomIcon(isZoomed)}
 			</button>`,
@@ -96,7 +91,7 @@ export const renderDetachButton = ({ showDetach, total, detach }) =>
 			html`<button
 				class="nav"
 				@click=${detach}
-				title="${_('Detach image to separate window')}"
+				title="${t('Detach image to separate window')}"
 			>
 				${launch}
 			</button>`,
@@ -109,7 +104,7 @@ export const renderDownloadButton = ({ total, onDownloadPdf }) =>
 			html`<button
 				class="nav"
 				@click=${onDownloadPdf}
-				title="${_('Download images')}"
+				title="${t('Download images')}"
 			>
 				${fileDownload}
 			</button>`,
@@ -122,20 +117,24 @@ export const renderPrintButton = ({ total, onPrintPdf }) =>
 			html`<button
 				class="nav"
 				@click=${onPrintPdf}
-				title="${_('Print images')}"
+				title="${t('Print images')}"
 			>
 				${printFile}
 			</button>`,
 	);
 
-export const renderFullscreenButton = ({ showFullscreen, total, openFullscreen }) =>
+export const renderFullscreenButton = ({
+	showFullscreen,
+	total,
+	openFullscreen,
+}) =>
 	when(
 		showFullscreen && total,
 		() =>
 			html`<button
 				class="nav"
 				@click=${openFullscreen}
-				title="${_('Fullscreen image')}"
+				title="${t('Fullscreen image')}"
 			>
 				${fullscreen}
 			</button>`,
@@ -148,7 +147,7 @@ export const renderCloseButton = ({ showClose, total, host }) =>
 			html`<button
 				class="nav"
 				@click=${() => host.dispatchEvent(new CustomEvent('close'))}
-				title="${_('Close fullscreen')}"
+				title="${t('Close fullscreen')}"
 			>
 				${closeIcon}
 			</button>`,
@@ -172,17 +171,16 @@ export const renderActions = (props) =>
 export const renderContentError = (contentError, total) =>
 	when(
 		contentError,
-		() => html`<p class="error">${_('Failed to load PDF.')}</p>`,
-		() => when(!total, () => html`<p>${_('No image loaded.')}</p>`),
+		() => html`<p class="error">${t('Failed to load PDF.')}</p>`,
+		() => when(!total, () => html`<p>${t('No image loaded.')}</p>`),
 	);
 
 export const renderMain = (props) =>
 	when(
 		!props.loading && !props.error,
 		() => html`
-			${when(
-				props.showPageNumber && props.total,
-				() => renderCounter(props.selectedImageNumber, props.total),
+			${when(props.showPageNumber && props.total, () =>
+				renderCounter(props.selectedImageNumber, props.total),
 			)}
 			${renderActions(props)}
 			${renderContentError(props.contentError, props.total)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,18 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@neovici/cosmoz-autocomplete": "^13.4.1",
-				"@neovici/cosmoz-i18next": "^3.2.2",
 				"@neovici/cosmoz-slider": "^5.2.0",
 				"@neovici/cosmoz-tokens": "^3.3.2",
 				"@neovici/cosmoz-utils": "^6.9.0",
 				"@pionjs/pion": "^2.5.2",
+				"i18next": ">=23.0.0 <27.0.0",
 				"jspdf": "^4.1.0",
 				"lit-html": "^2.0.0 || ^3.1.4"
 			},
 			"devDependencies": {
 				"@commitlint/cli": "^20.0.0",
 				"@commitlint/config-conventional": "^20.0.0",
-				"@neovici/cfg": "^2.8.0",
+				"@neovici/cfg": "^2.11.0",
 				"@open-wc/testing": "^4.0.0",
 				"@rollup/plugin-commonjs": "^29.0.2",
 				"@semantic-release/changelog": "^6.0.0",
@@ -1588,9 +1588,9 @@
 			}
 		},
 		"node_modules/@neovici/cfg": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cfg/-/cfg-2.8.0.tgz",
-			"integrity": "sha512-fW8jXsbRFhmZbB3YmVFZss/0lDDWhNimZk03aruj6Fp7O9cakIX5I1+EEqdM7TkHliZNika7bJXTZLhOg3SeEg==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cfg/-/cfg-2.11.1.tgz",
+			"integrity": "sha512-ZbmISYC3mS256hWg0MjZee7G4E7Y3Lmr4O5vsZJN1PcQ+IJVEPxKluaE5DiQD5CiNHxYpoMgVgumg3MNzd3eVw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1644,16 +1644,6 @@
 				"@neovici/cosmoz-utils": "^6.19.0",
 				"@pionjs/pion": "^2.5.2",
 				"lit-html": "^3.1.2"
-			}
-		},
-		"node_modules/@neovici/cosmoz-i18next": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-i18next/-/cosmoz-i18next-3.5.2.tgz",
-			"integrity": "sha512-T+kDuFJLhKGnhe3j9i28CofKTJHFU43XhNL9EKFXsqxpzn82+Dcc7SL6KtyeUnwIm3LaY30di/Qv1GQbGPnC1g==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@polymer/polymer": "^3.3.1",
-				"i18next": "^23.0.0"
 			}
 		},
 		"node_modules/@neovici/cosmoz-input": {
@@ -2005,14 +1995,6 @@
 			},
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/@polymer/polymer": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
-			"integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
-			"dependencies": {
-				"@webcomponents/shadycss": "^1.9.1"
 			}
 		},
 		"node_modules/@puppeteer/browsers": {
@@ -5651,11 +5633,6 @@
 			"engines": {
 				"node": ">=18.0.0"
 			}
-		},
-		"node_modules/@webcomponents/shadycss": {
-			"version": "1.11.2",
-			"resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
-			"integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 	},
 	"dependencies": {
 		"@neovici/cosmoz-autocomplete": "^13.4.1",
-		"@neovici/cosmoz-i18next": "^3.2.2",
+		"i18next": ">=23.0.0 <27.0.0",
 		"@neovici/cosmoz-slider": "^5.2.0",
 		"@neovici/cosmoz-tokens": "^3.3.2",
 		"@neovici/cosmoz-utils": "^6.9.0",
@@ -85,7 +85,7 @@
 	"devDependencies": {
 		"@commitlint/cli": "^20.0.0",
 		"@commitlint/config-conventional": "^20.0.0",
-		"@neovici/cfg": "^2.8.0",
+		"@neovici/cfg": "^2.11.0",
 		"@open-wc/testing": "^4.0.0",
 		"@rollup/plugin-commonjs": "^29.0.2",
 		"@semantic-release/changelog": "^6.0.0",

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,4 +1,10 @@
 import { assert } from '@open-wc/testing';
+import i18next from 'i18next';
+i18next.init({
+	lng: 'en',
+	resources: { en: { translation: {} } },
+	fallbackLng: false,
+});
 
 export const HAS_NEW_TOUCH = (() => {
 		try {


### PR DESCRIPTION
## Summary
- Replace `_()` from @neovici/cosmoz-i18next with `t()` from i18next
- Remove @neovici/cosmoz-i18next dependency
- Add i18next >=23.0.0 <27.0.0 as direct dependency
- No translation key or interpolation format changes — `{0}` placeholders unchanged
- Part of FE-609 (fix duplicate singleton packages) / FE-623

Resolves FE-623