### PR TITLE
fix(render): null-check error container in onImageError

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -5,13 +5,16 @@ import { guard } from 'lit-html/directives/guard.js';
 import { until } from 'lit-html/directives/until.js';
 
 const onImageError = (e) => {
-	if (!e.currentTarget.parentElement) {
+	const { currentTarget } = e;
+	if (!currentTarget.isConnected || !currentTarget.parentElement) {
 		return;
 	}
 
-	const errorContainer = e.currentTarget.parentElement.querySelector('.error');
-	errorContainer.removeAttribute('hidden');
-	e.currentTarget.setAttribute('hidden', true);
+	const errorContainer = currentTarget.parentElement.querySelector('.error');
+	if (errorContainer) {
+		errorContainer.removeAttribute('hidden');
+	}
+	currentTarget.setAttribute('hidden', true);
 };
 
 const onStatusChanged = (ev) => ev.detail.value === 'error' && onImageError(ev);


### PR DESCRIPTION
## Fix for FE-857

### Problem
In `cosmoz-image-viewer`, an image `onload`/`onerror` callback accesses `element.parentElement.querySelector(...).removeAttribute(...)` after the image element has been removed from the DOM, causing:

```
Uncaught TypeError: Cannot read properties of null (reading 'removeAttribute') at HTMLImageElement.$e
```

**Impact (last 7 days, App Insights prod):** 140 errors, 31 unique users, 47 sessions (Edge 111, Firefox 19, Chrome 10).

### Root cause
`lib/render.js` — `onImageError` guarded against `parentElement` being null, but not against `querySelector('.error')` returning null. When the image (or `haunted-pan-zoom`) is detached from the DOM before the `error`/`status-changed` callback fires, `parentElement` may be non-null while `.error` cannot be found, so `errorContainer.removeAttribute('hidden')` throws.

### Fix
Harden `onImageError` with:
1. An `isConnected` check on `currentTarget` to abort early when the image is no longer attached to the DOM.
2. A null-check on the queried `errorContainer` before calling `removeAttribute`.

### Verification
- `npm run lint` — passes (only pre-existing warnings remain)
- `npm test` — 45/45 pass (Chromium + Firefox)
- `npm run prettier:check` — no new issues introduced

Closes Neovici/cosmoz-image-viewer FE-857.