### PR TITLE
fix(render): split error handlers to fix non-zoom crash

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -6,18 +6,30 @@ import { until } from 'lit-html/directives/until.js';
 
 const onImageError = (e) => {
 	const { currentTarget } = e;
-	if (!currentTarget.isConnected || !currentTarget.parentElement) {
+	if (!currentTarget.isConnected) {
 		return;
 	}
-
-	const errorContainer = currentTarget.parentElement.querySelector('.error');
+	const slideWrapper = currentTarget.parentElement?.parentElement;
+	const errorContainer = slideWrapper?.querySelector('.error');
 	if (errorContainer) {
 		errorContainer.removeAttribute('hidden');
 	}
 	currentTarget.setAttribute('hidden', true);
 };
 
-const onStatusChanged = (ev) => ev.detail.value === 'error' && onImageError(ev);
+const onZoomError = (e) => {
+	const { currentTarget } = e;
+	if (!currentTarget.isConnected) {
+		return;
+	}
+	const errorContainer = currentTarget.parentElement?.querySelector('.error');
+	if (errorContainer) {
+		errorContainer.removeAttribute('hidden');
+	}
+	currentTarget.setAttribute('hidden', true);
+};
+
+const onStatusChanged = (e) => e.detail.value === 'error' && onZoomError(e);
 
 export const renderImage = ({ src$, showZoom, isZoomed, index }) => {
 	const src = guard(src$, () => until(src$));

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -123,6 +123,43 @@ suite('cosmoz-image-viewer with no images', () => {
 	});
 });
 
+suite('cosmoz-image-viewer-non-zoom-loading-error', () => {
+	setup(async () => {
+		await fixture(
+			html`<cosmoz-image-viewer
+				show-nav
+				show-fullscreen
+				show-page-number
+				show-detach
+				.source=${[
+					{
+						title: 'Errors',
+						images: [
+							'xyz.jpg',
+							'/stories/images/stockholm.jpg',
+							'/stories/images/strasbourg.jpg',
+						].map(absolute),
+					},
+				]}
+			></cosmoz-image-viewer>`,
+		);
+	});
+
+	test('error is shown when image fails to load without zoom', async () => {
+		await perform(async ({ page, expect }) => {
+			await expect(
+				page.locator('"An error occurred while loading the image."'),
+			).toBeVisible();
+
+			await page.locator('cosmoz-image-viewer').hover();
+			await page.locator('button[name="next"]').click();
+			await expect(
+				page.locator('img[src$="/stories/images/stockholm.jpg"]'),
+			).toBeVisible();
+		});
+	});
+});
+
 suite('cosmoz-image-viewer-loading-error', () => {
 	setup(async () => {
 		await fixture(


### PR DESCRIPTION
## Problem

`onImageError` crashes with `TypeError: Cannot read properties of null (reading 'removeAttribute')` when an image fails to load in the non-zoom path (`showZoom=false`).

**Root cause:** The `.error` div is a sibling of `.image-container` (rendered in `renderSlide`), not a child. In the non-zoom path, `<img>`'s `parentElement` is `.image-container`, so `parentElement.querySelector(.error)` returns `null` — calling `null.removeAttribute(hidden)` crashes.

PR #331 added a null-check to prevent the crash, but the error UI still never shows in the non-zoom path because `.error` is never found.

## Fix

Split into two dedicated error handlers, each with the correct DOM traversal for its context:

- **`onImageError`** (non-zoom): `<img @error>` handler. Traverses two levels up (`img` → `.image-container` → slide wrapper `<div>`) to find `.error`.
- **`onZoomError`** (zoom): Called by `onStatusChanged` on `haunted-pan-zoom @status-changed`. Traverses one level up (`haunted-pan-zoom` → slide wrapper `<div>`) to find `.error`.

`onStatusChanged` is preserved as the event handler, filtering for `detail.value === error` before delegating to `onZoomError`.

## Test

Added `cosmoz-image-viewer-non-zoom-loading-error` suite that verifies the error message appears when an image fails to load with `showZoom=false`.

Re https://linear.app/neovici/issue/FE-857/fix-removeattribute-crash-in-cz-image-viewer-when-image-element-is
Fixes https://linear.app/neovici/issue/FE-639/fix-cosmoz-image-viewer-crash-on-missing-invoice-image