### PR TITLE
chore: add changeset for non-zoom error crash fix

### DIFF
--- a/.changeset/fix-nonzoom-error-crash.md
+++ b/.changeset/fix-nonzoom-error-crash.md
@@ -1,0 +1,9 @@
+---
+'@neovici/cosmoz-image-viewer': patch
+---
+
+Fix crash when image fails to load in non-zoom path
+
+Split error handlers so the non-zoom `<img>` error handler correctly
+traverses the DOM to find the `.error` container, instead of returning
+null and crashing on `removeAttribute`.


### PR DESCRIPTION
Adds the missing changeset for #335 (FE-857, FE-639).

The fix was already merged but the changeset was omitted.